### PR TITLE
Migrate docker jest tests to vitest

### DIFF
--- a/tools/dev-server/src/__tests__/docker-manager.test.ts
+++ b/tools/dev-server/src/__tests__/docker-manager.test.ts
@@ -2,9 +2,10 @@
 import { DockerManager } from "../docker-manager";
 import { spawn } from "child_process";
 import { EventEmitter } from "events";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
-jest.mock("child_process");
-const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+vi.mock("child_process");
+const mockSpawn = vi.mocked(spawn);
 
 describe("DockerManager", () => {
   let dockerManager: DockerManager;
@@ -19,7 +20,7 @@ describe("DockerManager", () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe("startOllama", () => {

--- a/tools/testing/src/docker-integration.test.ts
+++ b/tools/testing/src/docker-integration.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "child_process";
 import { promisify } from "util";
 import fetch from "node-fetch";
 import path from "path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 const exec = promisify(require("child_process").exec);
 

--- a/tools/testing/src/e2e-docker.test.ts
+++ b/tools/testing/src/e2e-docker.test.ts
@@ -1,4 +1,14 @@
 // tools/testing/src/e2e-docker.test.ts
+import { spawn } from "child_process";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { promisify } from "util";
+import fetch from "node-fetch";
+import { describe, it, expect } from "vitest";
+
+const exec = promisify(require("child_process").exec);
+
 describe("End-to-End Docker Development Workflow", () => {
   it("should complete full development cycle with Docker", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "farm-e2e-"));

--- a/tools/testing/src/platform-docker.test.ts
+++ b/tools/testing/src/platform-docker.test.ts
@@ -1,4 +1,6 @@
 // tools/testing/src/platform-docker.test.ts
+import { describe, it } from "vitest";
+
 describe("Cross-Platform Docker Support", () => {
   describe("Windows", () => {
     it("should handle Windows Docker Desktop", async () => {

--- a/tools/testing/src/template-docker.test.ts
+++ b/tools/testing/src/template-docker.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "child_process";
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 describe("Template Docker Generation", () => {
   let tempDir: string;


### PR DESCRIPTION
## Summary
- switch Docker-related tests from Jest to Vitest

## Testing
- `pnpm install` *(fails: uvicorn postinstall error)*

------
https://chatgpt.com/codex/tasks/task_e_68428044a6448323b818526570b36267