### PR TITLE
Fix CLI package path resolution

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,14 +2,15 @@
 import { Command } from "commander";
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { createCreateCommand } from "./commands/create.js";
 import { createDevCommand } from "./commands/dev.js";
 import { createBuildCommand } from "./commands/build.js";
 import { createGenerateCommand } from "./commands/generate.js";
 import { createValidateCommands } from "./commands/validate";
-const __dirname = process.cwd();
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(
-  readFileSync(join(__dirname, "packages/cli/package.json"), "utf-8")
+  readFileSync(join(__dirname, "..", "package.json"), "utf-8")
 );
 
 export function createCLI(): Command {

--- a/packages/cli/src/core/cli.ts
+++ b/packages/cli/src/core/cli.ts
@@ -4,26 +4,24 @@ import chalk from "chalk";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { createRequire } from "module";
+import { fileURLToPath } from "url";
 import { styles, icons, messages } from "../utils/styling.js";
 import { createProject } from "../commands/create.js";
 import { getErrorMessage } from "../utils/error-handling.js";
 
-// Handle __dirname for both CommonJS and ESM
-const __dirname = process.cwd();
+// Resolve __dirname based on module URL for both CJS and ESM
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Get package.json information
  */
 export function getPackageInfo() {
-  // Try multiple possible package.json locations
+  // Possible locations of package.json relative to this file
   const possiblePaths = [
-    // When running from built CLI in monorepo context
-    join(process.cwd(), "packages", "cli", "package.json"),
-    // When running built CLI from its own directory
-    join(__dirname, "..", "package.json"),
-    // When running from source
+    // dist/core or src/core
     join(__dirname, "..", "..", "package.json"),
-    // Fallback: relative to current file location
+    // when executed from package root
+    join(__dirname, "..", "package.json"),
     join(__dirname, "package.json"),
   ];
 


### PR DESCRIPTION
## Summary
- use `import.meta.url` to resolve paths in CLI
- ensure package.json is found no matter where `farm` is executed

## Testing
- `pnpm --filter @farm/cli build`
- `node packages/cli/dist/index.js --version`
- `node /workspace/farm-framework/packages/cli/dist/index.js --version`
- `/root/.local/share/pnpm/global/5/node_modules/.bin/farm --version`
- `farm --version`


------
https://chatgpt.com/codex/tasks/task_e_684428b6e95083238a20c55ce0c840a0