### PR TITLE
Add ai-dashboard template files

### DIFF
--- a/templates/ai-dashboard/README.md.hbs
+++ b/templates/ai-dashboard/README.md.hbs
@@ -1,0 +1,19 @@
+# {{projectName}}
+
+{{description}}
+
+This project is generated with the **FARM Stack Framework** using the `ai-dashboard` template. It includes a FastAPI backend that exposes analytics and AI insight endpoints and a React + Vite frontend displaying interactive dashboards.
+
+## Development
+
+```bash
+# Start frontend
+cd apps/web && npm install && npm run dev
+
+# Start backend
+cd ../api && pip install -r requirements.txt && uvicorn src.main:app --reload
+```
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` to configure database and AI providers.

--- a/templates/ai-dashboard/apps/api/pyproject.toml.hbs
+++ b/templates/ai-dashboard/apps/api/pyproject.toml.hbs
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{projectName}}-api"
+version = "0.1.0"
+description = "{{description}}"
+authors = [{name = "{{author}}"}]
+dependencies = [
+  "fastapi>=0.104.0",
+  "uvicorn[standard]>=0.24.0",
+  "pydantic>=2.0.0",
+  "motor>=3.3.0",
+  "beanie>=1.23.0",
+  "pandas>=2.1.0",
+  "scikit-learn>=1.3.0"
+]
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
+  "pytest-asyncio>=0.21.0",
+  "black>=23.0.0",
+  "isort>=5.0.0",
+  "mypy>=1.0.0"
+]
+
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+python_version = "3.11"

--- a/templates/ai-dashboard/apps/api/requirements.txt.hbs
+++ b/templates/ai-dashboard/apps/api/requirements.txt.hbs
@@ -1,0 +1,7 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+pydantic>=2.0.0
+motor>=3.3.0
+beanie>=1.23.0
+pandas>=2.1.0
+scikit-learn>=1.3.0

--- a/templates/ai-dashboard/apps/api/src/ai/analytics.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/ai/analytics.py.hbs
@@ -1,0 +1,9 @@
+"""Utility functions for analytics calculations."""
+
+import pandas as pd
+
+async def compute_metrics(df: pd.DataFrame) -> dict:
+    return {
+        "Users": int(df['user_id'].nunique()),
+        "Sessions": int(df['session_id'].nunique()),
+    }

--- a/templates/ai-dashboard/apps/api/src/ai/insights_generator.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/ai/insights_generator.py.hbs
@@ -1,0 +1,11 @@
+"""Generate textual insights from metrics."""
+
+from .analytics import compute_metrics
+import pandas as pd
+
+async def generate_insights(df: pd.DataFrame) -> list[dict]:
+    metrics = await compute_metrics(df)
+    insights = []
+    if metrics["Users"] > 100:
+        insights.append({"title": "Growth", "detail": "User base is growing"})
+    return insights

--- a/templates/ai-dashboard/apps/api/src/ai/trend_analysis.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/ai/trend_analysis.py.hbs
@@ -1,0 +1,9 @@
+"""Simple trend analysis utilities."""
+
+import pandas as pd
+
+async def calculate_trend(df: pd.DataFrame, column: str) -> float:
+    values = df[column].tolist()
+    if len(values) < 2:
+        return 0.0
+    return (values[-1] - values[0]) / max(values[0], 1)

--- a/templates/ai-dashboard/apps/api/src/ml/data_processor.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/ml/data_processor.py.hbs
@@ -1,0 +1,6 @@
+"""Simple data processing utilities."""
+
+import pandas as pd
+
+async def load_csv(path: str) -> pd.DataFrame:
+    return pd.read_csv(path)

--- a/templates/ai-dashboard/apps/api/src/ml/model_manager.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/ml/model_manager.py.hbs
@@ -1,0 +1,11 @@
+"""Basic ML model manager placeholder."""
+
+class ModelManager:
+    def __init__(self):
+        self.models: dict[str, object] = {}
+
+    def register(self, name: str, model: object) -> None:
+        self.models[name] = model
+
+    def get(self, name: str) -> object | None:
+        return self.models.get(name)

--- a/templates/ai-dashboard/apps/api/src/models/dataset.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/models/dataset.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Dataset(BaseModel):
+    name: str
+    records: int

--- a/templates/ai-dashboard/apps/api/src/models/insight.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/models/insight.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Insight(BaseModel):
+    title: str
+    detail: str

--- a/templates/ai-dashboard/apps/api/src/models/metric.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/models/metric.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Metric(BaseModel):
+    name: str
+    value: int | float

--- a/templates/ai-dashboard/apps/api/src/routes/ai_insights.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/routes/ai_insights.py.hbs
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+from ..models.insight import Insight
+
+router = APIRouter(prefix="/ai-insights", tags=["ai"])
+
+@router.get("/", response_model=list[Insight])
+async def get_insights():
+    """Return AI generated insights."""
+    return [
+        Insight(title="Trend", detail="Sales are increasing"),
+        Insight(title="Warning", detail="Churn rate rising"),
+    ]

--- a/templates/ai-dashboard/apps/api/src/routes/analytics.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/routes/analytics.py.hbs
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+from ..models.metric import Metric
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+@router.get("/", response_model=list[Metric])
+async def list_metrics():
+    """Return a list of metrics for the dashboard."""
+    return [
+        Metric(name="Users", value=120),
+        Metric(name="Sessions", value=340),
+    ]

--- a/templates/ai-dashboard/apps/api/src/routes/dashboard.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/routes/dashboard.py.hbs
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from ..models.dataset import Dataset
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+@router.get("/data", response_model=Dataset)
+async def dashboard_data():
+    """Return demo dashboard dataset."""
+    return Dataset(name="demo", records=1000)

--- a/templates/ai-dashboard/apps/api/src/routes/data.py.hbs
+++ b/templates/ai-dashboard/apps/api/src/routes/data.py.hbs
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/data", tags=["data"])
+
+@router.get("/")
+async def get_data(type: str):
+    """Return chart data by type."""
+    return {
+        "type": type,
+        "values": [1, 2, 3, 4]
+    }

--- a/templates/ai-dashboard/apps/web/package.json.hbs
+++ b/templates/ai-dashboard/apps/web/package.json.hbs
@@ -1,0 +1,29 @@
+{
+  "name": "{{projectName}}-web",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@tanstack/react-query": "^5.0.0",
+    "zustand": "^4.4.0",
+    "react-router-dom": "^6.0.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0"
+  }
+}

--- a/templates/ai-dashboard/apps/web/src/components/ai/AIInsights.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/ai/AIInsights.tsx.hbs
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function AIInsights({ insights }: { insights: string[] }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-lg font-semibold mb-2">AI Insights</h3>
+      <ul className="list-disc list-inside space-y-1">
+        {insights.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/ai/ModelPerformance.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/ai/ModelPerformance.tsx.hbs
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Perf {
+  model: string;
+  score: number;
+}
+
+export default function ModelPerformance({ data }: { data: Perf[] }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-lg font-semibold mb-2">Model Performance</h3>
+      <ul className="space-y-1">
+        {data.map(p => (
+          <li key={p.model} className="text-sm text-gray-700">
+            {p.model}: {p.score}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/ai/PredictionViewer.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/ai/PredictionViewer.tsx.hbs
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Prediction {
+  input: string;
+  output: string;
+}
+
+export default function PredictionViewer({ predictions }: { predictions: Prediction[] }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-lg font-semibold mb-2">Predictions</h3>
+      <ul className="space-y-1">
+        {predictions.map((p, i) => (
+          <li key={i} className="text-sm text-gray-700">
+            <strong>{p.input}:</strong> {p.output}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/charts/BarChart.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/charts/BarChart.tsx.hbs
@@ -1,0 +1,7 @@
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+export default function BarChart({ data }: { data: any }) {
+  return <Bar data={data} />;
+}

--- a/templates/ai-dashboard/apps/web/src/components/charts/HeatMap.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/charts/HeatMap.tsx.hbs
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function HeatMap({ data }: { data: number[][] }) {
+  return (
+    <div className="grid" style={{ gridTemplateColumns: `repeat(${data[0]?.length || 0}, 1fr)` }}>
+      {data.flat().map((v, i) => (
+        <div
+          key={i}
+          style={{ backgroundColor: `rgba(0,0,255,${v})` }}
+          className="w-full h-6"
+        />
+      ))}
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/charts/LineChart.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/charts/LineChart.tsx.hbs
@@ -1,0 +1,7 @@
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend } from 'chart.js';
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend);
+
+export default function LineChart({ data }: { data: any }) {
+  return <Line data={data} />;
+}

--- a/templates/ai-dashboard/apps/web/src/components/charts/PieChart.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/charts/PieChart.tsx.hbs
@@ -1,0 +1,7 @@
+import { Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+export default function PieChart({ data }: { data: any }) {
+  return <Pie data={data} />;
+}

--- a/templates/ai-dashboard/apps/web/src/components/dashboard/AISummary.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/dashboard/AISummary.tsx.hbs
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AISummary({ summary }: { summary: string }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-lg font-semibold mb-2">AI Summary</h3>
+      <p className="text-sm text-gray-700 whitespace-pre-line">{summary}</p>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/dashboard/DashboardGrid.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/dashboard/DashboardGrid.tsx.hbs
@@ -1,0 +1,37 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+import InsightPanel from './InsightPanel';
+import AISummary from './AISummary';
+import LineChart from '../charts/LineChart';
+import BarChart from '../charts/BarChart';
+import PieChart from '../charts/PieChart';
+import HeatMap from '../charts/HeatMap';
+import { useAnalytics } from '../../hooks/useAnalytics';
+
+export default function DashboardGrid() {
+  const { data, isLoading } = useAnalytics();
+
+  if (isLoading) return <p>Loading...</p>;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {data?.metrics.map((m: any) => (
+          <MetricCard key={m.title} title={m.title} value={m.value} />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <LineChart data={data?.lineData} />
+        <BarChart data={data?.barData} />
+        <PieChart data={data?.pieData} />
+        <HeatMap data={data?.heatData} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <InsightPanel insights={data?.insights} />
+        <AISummary summary={data?.summary} />
+      </div>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/dashboard/InsightPanel.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/dashboard/InsightPanel.tsx.hbs
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Insight {
+  title: string;
+  detail: string;
+}
+
+export default function InsightPanel({ insights }: { insights: Insight[] }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-lg font-semibold mb-2">Insights</h3>
+      <ul className="space-y-2">
+        {insights?.map((insight) => (
+          <li key={insight.title} className="text-sm text-gray-700">
+            <strong>{insight.title}:</strong> {insight.detail}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/components/dashboard/MetricCard.tsx.hbs
+++ b/templates/ai-dashboard/apps/web/src/components/dashboard/MetricCard.tsx.hbs
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface MetricCardProps {
+  title: string;
+  value: number | string;
+}
+
+export default function MetricCard({ title, value }: MetricCardProps) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="text-sm text-gray-500">{title}</h3>
+      <p className="text-2xl font-semibold text-gray-900">{value}</p>
+    </div>
+  );
+}

--- a/templates/ai-dashboard/apps/web/src/hooks/useAIInsights.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/hooks/useAIInsights.ts.hbs
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useAIInsights() {
+  return useQuery({
+    queryKey: ['ai-insights'],
+    queryFn: async () => {
+      const res = await fetch('/api/ai-insights');
+      if (!res.ok) throw new Error('Failed to load AI insights');
+      return res.json();
+    },
+  });
+}

--- a/templates/ai-dashboard/apps/web/src/hooks/useAnalytics.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/hooks/useAnalytics.ts.hbs
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useAnalytics() {
+  return useQuery({
+    queryKey: ['analytics'],
+    queryFn: async () => {
+      const res = await fetch('/api/analytics');
+      if (!res.ok) throw new Error('Failed to load analytics');
+      return res.json();
+    },
+  });
+}

--- a/templates/ai-dashboard/apps/web/src/hooks/useChartData.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/hooks/useChartData.ts.hbs
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useChartData(type: string) {
+  return useQuery({
+    queryKey: ['chart', type],
+    queryFn: async () => {
+      const res = await fetch(`/api/data?type=${type}`);
+      if (!res.ok) throw new Error('Failed to load chart data');
+      return res.json();
+    },
+  });
+}

--- a/templates/ai-dashboard/apps/web/src/hooks/useMLModels.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/hooks/useMLModels.ts.hbs
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function useMLModels() {
+  return useQuery({
+    queryKey: ['ml-models'],
+    queryFn: async () => {
+      const res = await fetch('/api/models');
+      if (!res.ok) throw new Error('Failed to load models');
+      return res.json();
+    },
+  });
+}

--- a/templates/ai-dashboard/apps/web/src/stores/analyticsStore.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/stores/analyticsStore.ts.hbs
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface AnalyticsState {
+  refreshInterval: number;
+  setRefreshInterval: (ms: number) => void;
+}
+
+export const useAnalyticsStore = create<AnalyticsState>(set => ({
+  refreshInterval: 60000,
+  setRefreshInterval: ms => set({ refreshInterval: ms }),
+}));

--- a/templates/ai-dashboard/apps/web/src/stores/dashboardStore.ts.hbs
+++ b/templates/ai-dashboard/apps/web/src/stores/dashboardStore.ts.hbs
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface DashboardState {
+  selectedModel: string;
+  setSelectedModel: (model: string) => void;
+}
+
+export const useDashboardStore = create<DashboardState>(set => ({
+  selectedModel: '',
+  setSelectedModel: model => set({ selectedModel: model }),
+}));

--- a/templates/ai-dashboard/apps/web/tailwind.config.js.hbs
+++ b/templates/ai-dashboard/apps/web/tailwind.config.js.hbs
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/templates/ai-dashboard/apps/web/vite.config.ts.hbs
+++ b/templates/ai-dashboard/apps/web/vite.config.ts.hbs
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});

--- a/templates/ai-dashboard/docker-compose.yml.hbs
+++ b/templates/ai-dashboard/docker-compose.yml.hbs
@@ -1,0 +1,56 @@
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:7.0
+    ports:
+      - '27017:27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: {{projectName}}
+      MONGO_INITDB_ROOT_PASSWORD: development
+    volumes:
+      - mongodb_data:/data/db
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - '11434:11434'
+    volumes:
+      - ollama_models:/root/.ollama
+    environment:
+      - OLLAMA_ORIGINS=*
+      - OLLAMA_HOST=0.0.0.0
+    restart: unless-stopped
+
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+    ports:
+      - '8000:8000'
+    environment:
+      - DATABASE_URL=mongodb://{{projectName}}:development@mongodb:27017
+      - OLLAMA_URL=http://ollama:11434
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - mongodb
+      - ollama
+    volumes:
+      - ./apps/api:/app
+
+  web:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile.dev
+    ports:
+      - '3000:3000'
+    environment:
+      - VITE_API_URL=http://localhost:8000
+    depends_on:
+      - api
+    volumes:
+      - ./apps/web:/app
+      - /app/node_modules
+
+volumes:
+  mongodb_data:
+  ollama_models:

--- a/templates/ai-dashboard/farm.config.ts.hbs
+++ b/templates/ai-dashboard/farm.config.ts.hbs
@@ -1,0 +1,55 @@
+import { defineConfig } from '@farm/core';
+
+export default defineConfig({
+  name: '{{projectName}}',
+  version: '1.0.0',
+  description: '{{description}}',
+  template: 'ai-dashboard',
+  features: [{{#each features}}'{{this}}'{{#unless @last}}, {{/unless}}{{/each}}],
+  database: {
+    type: '{{database.type}}',
+    url: process.env.DATABASE_URL || '{{database.defaultUrl}}'
+  },
+  ai: {
+    providers: {
+      {{#if ai.ollama.enabled}}
+      ollama: {
+        enabled: true,
+        url: 'http://localhost:11434',
+        models: [{{#each ai.ollama.models}}'{{this}}'{{#unless @last}}, {{/unless}}{{/each}}],
+        defaultModel: '{{ai.ollama.defaultModel}}'
+      },
+      {{/if}}
+      {{#if ai.openai.enabled}}
+      openai: {
+        enabled: true,
+        apiKey: process.env.OPENAI_API_KEY,
+        models: [{{#each ai.openai.models}}'{{this}}'{{#unless @last}}, {{/unless}}{{/each}}],
+        defaultModel: '{{ai.openai.defaultModel}}'
+      }
+      {{/if}}
+    },
+    routing: {
+      development: '{{ai.routing.development}}',
+      staging: '{{ai.routing.staging}}',
+      production: '{{ai.routing.production}}'
+    },
+    features: {
+      streaming: true,
+      caching: true
+    }
+  },
+  development: {
+    ports: {
+      frontend: 3000,
+      backend: 8000,
+      proxy: 4000{{#if ai.ollama.enabled}},
+      ollama: 11434{{/if}}
+    },
+    hotReload: {
+      enabled: true,
+      typeGeneration: true,
+      aiModels: true
+    }
+  }
+});

--- a/templates/ai-dashboard/package.json.hbs
+++ b/templates/ai-dashboard/package.json.hbs
@@ -1,0 +1,30 @@
+{
+  "name": "{{projectName}}",
+  "version": "0.1.0",
+  "description": "{{description}}",
+  "private": true,
+  "type": "module",
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "dev": "concurrently \"npm run dev:api\" \"npm run dev:web\"",
+    "dev:web": "cd apps/web && npm run dev",
+    "build:web": "cd apps/web && npm run build",
+    "preview:web": "cd apps/web && npm run preview",
+    "dev:api": "cd apps/api && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000",
+    "test:api": "cd apps/api && pytest",
+    "lint:api": "cd apps/api && black . && isort .",
+    "type-check:api": "cd apps/api && mypy ."
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
+  },
+  "keywords": [
+    "farm-stack",
+    "fastapi",
+    "react",
+    "dashboard",
+    "ai"
+  ],
+  "author": "{{author}}",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add README and configuration for ai-dashboard template
- add docker-compose and package templates
- scaffold web dashboard components, hooks, stores
- scaffold API routes, models, and utilities

## Testing
- `pnpm run validate:templates` *(fails: Cannot find module `dist/template-validator.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6844c93c8b44832399ad8e2f2d77acba