### PR TITLE
Add feature templates for AI, auth and realtime

### DIFF
--- a/templates/other/features/ai/apps/api/src/ai/__init__.py.hbs
+++ b/templates/other/features/ai/apps/api/src/ai/__init__.py.hbs
@@ -1,0 +1,1 @@
+"""AI utilities"""

--- a/templates/other/features/ai/apps/api/src/ai/gpu_utils.py.hbs
+++ b/templates/other/features/ai/apps/api/src/ai/gpu_utils.py.hbs
@@ -1,0 +1,8 @@
+"""GPU utility helpers."""
+
+def has_cuda() -> bool:
+    try:
+        import torch  # type: ignore
+        return torch.cuda.is_available()
+    except Exception:
+        return False

--- a/templates/other/features/ai/apps/api/src/ai/inference.py.hbs
+++ b/templates/other/features/ai/apps/api/src/ai/inference.py.hbs
@@ -1,0 +1,6 @@
+from .ollama_client import OllamaClient
+
+client = OllamaClient()
+
+async def generate_text(prompt: str, model: str) -> str:
+    return await client.generate(prompt, model)

--- a/templates/other/features/ai/apps/api/src/ai/model_manager.py.hbs
+++ b/templates/other/features/ai/apps/api/src/ai/model_manager.py.hbs
@@ -1,0 +1,16 @@
+from typing import Dict
+
+class ModelManager:
+    """Simple model registry."""
+
+    def __init__(self):
+        self.loaded: Dict[str, bool] = {}
+
+    async def load(self, model: str):
+        self.loaded[model] = True
+
+    async def unload(self, model: str):
+        self.loaded.pop(model, None)
+
+    def is_loaded(self, model: str) -> bool:
+        return self.loaded.get(model, False)

--- a/templates/other/features/ai/apps/api/src/ai/ollama_client.py.hbs
+++ b/templates/other/features/ai/apps/api/src/ai/ollama_client.py.hbs
@@ -1,0 +1,11 @@
+import httpx
+
+class OllamaClient:
+    def __init__(self, base_url: str = "http://localhost:11434"):
+        self.client = httpx.AsyncClient(base_url=base_url)
+
+    async def generate(self, prompt: str, model: str) -> str:
+        resp = await self.client.post("/api/generate", json={"model": model, "prompt": prompt, "stream": False})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response") or data.get("generated", "")

--- a/templates/other/features/ai/apps/api/src/routes/ai.py.hbs
+++ b/templates/other/features/ai/apps/api/src/routes/ai.py.hbs
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from ..ai.inference import generate_text
+
+router = APIRouter(prefix="/ai")
+
+@router.post("/generate")
+async def generate(prompt: str, model: str = "llama3"):
+    result = await generate_text(prompt, model)
+    return {"result": result}

--- a/templates/other/features/ai/apps/web/src/components/ai/AIResponse.tsx.hbs
+++ b/templates/other/features/ai/apps/web/src/components/ai/AIResponse.tsx.hbs
@@ -1,0 +1,9 @@
+import React from 'react';
+
+interface Props {
+  content: string;
+}
+
+export default function AIResponse({ content }: Props) {
+  return <pre className="whitespace-pre-wrap">{content}</pre>;
+}

--- a/templates/other/features/ai/apps/web/src/components/ai/InferenceStatus.tsx.hbs
+++ b/templates/other/features/ai/apps/web/src/components/ai/InferenceStatus.tsx.hbs
@@ -1,0 +1,7 @@
+interface Props {
+  status: string;
+}
+
+export default function InferenceStatus({ status }: Props) {
+  return <div className="text-sm text-gray-500">{status}</div>;
+}

--- a/templates/other/features/ai/apps/web/src/components/ai/ModelSelector.tsx.hbs
+++ b/templates/other/features/ai/apps/web/src/components/ai/ModelSelector.tsx.hbs
@@ -1,0 +1,25 @@
+import type { ModelInfo } from '../../hooks/useAIModels';
+
+interface Props {
+  provider: string;
+  selectedModel: string;
+  models: ModelInfo[];
+  loading?: boolean;
+  onModelChange: (model: string) => void;
+}
+
+export default function ModelSelector({ provider, selectedModel, models, loading, onModelChange }: Props) {
+  return (
+    <select
+      className="border rounded px-2 py-1 text-sm"
+      value={selectedModel}
+      onChange={(e) => onModelChange(e.target.value)}
+      disabled={loading}
+    >
+      <option value="" disabled>Select model</option>
+      {models.map((m) => (
+        <option key={m.name} value={m.name}>{m.name}</option>
+      ))}
+    </select>
+  );
+}

--- a/templates/other/features/ai/apps/web/src/hooks/useAIInference.ts.hbs
+++ b/templates/other/features/ai/apps/web/src/hooks/useAIInference.ts.hbs
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export function useAIInference(model: string) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const infer = async (prompt: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ai/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, model })
+      });
+      if (!res.ok) throw new Error('Inference failed');
+      const data = await res.json();
+      return data.result as string;
+    } catch (e: any) {
+      setError(e.message);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { infer, loading, error };
+}

--- a/templates/other/features/ai/apps/web/src/hooks/useStreamingAI.ts.hbs
+++ b/templates/other/features/ai/apps/web/src/hooks/useStreamingAI.ts.hbs
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export function useStreamingAI(model: string) {
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const start = (prompt: string) => {
+    setResponse('');
+    setLoading(true);
+    const url = `/api/ai/generate/stream?model=${model}&prompt=${encodeURIComponent(prompt)}`;
+    const es = new EventSource(url);
+    es.onmessage = (e) => {
+      if (e.data === '[DONE]') {
+        es.close();
+        setLoading(false);
+      } else {
+        setResponse((prev) => prev + e.data);
+      }
+    };
+    es.onerror = () => {
+      es.close();
+      setLoading(false);
+    };
+  };
+
+  return { start, response, loading };
+}

--- a/templates/other/features/authentication/apps/api/src/auth/__init__.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/auth/__init__.py.hbs
@@ -1,0 +1,1 @@
+"""Authentication utilities"""

--- a/templates/other/features/authentication/apps/api/src/auth/jwt.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/auth/jwt.py.hbs
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+from jose import jwt, JWTError
+
+SECRET_KEY = "CHANGE_ME"
+ALGORITHM = "HS256"
+
+def create_access_token(data: dict, expires_minutes: int = 30) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(minutes=expires_minutes)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def verify_token(token: str):
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        return None

--- a/templates/other/features/authentication/apps/api/src/auth/middleware.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/auth/middleware.py.hbs
@@ -1,0 +1,11 @@
+from fastapi import Request, HTTPException
+from fastapi.security.utils import get_authorization_scheme_param
+from .jwt import verify_token
+
+async def auth_middleware(request: Request, call_next):
+    auth = request.headers.get('Authorization')
+    if auth:
+        scheme, token = get_authorization_scheme_param(auth)
+        if scheme.lower() == 'bearer' and verify_token(token):
+            return await call_next(request)
+    raise HTTPException(status_code=401, detail='Not authenticated')

--- a/templates/other/features/authentication/apps/api/src/auth/oauth.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/auth/oauth.py.hbs
@@ -1,0 +1,3 @@
+from fastapi.security import OAuth2PasswordBearer
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")

--- a/templates/other/features/authentication/apps/api/src/models/token.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/models/token.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str

--- a/templates/other/features/authentication/apps/api/src/models/user.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/models/user.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class User(BaseModel):
+    username: str
+    email: str | None = None

--- a/templates/other/features/authentication/apps/api/src/routes/auth.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/routes/auth.py.hbs
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from ..auth.jwt import create_access_token
+
+router = APIRouter(prefix="/auth")
+
+class Login(BaseModel):
+    username: str
+    password: str
+
+fake_user = {"username": "admin", "password": "password"}
+
+@router.post("/login")
+async def login(data: Login):
+    if data.username == fake_user["username"] and data.password == fake_user["password"]:
+        token = create_access_token({"sub": data.username})
+        return {"access_token": token, "token_type": "bearer"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/templates/other/features/authentication/apps/api/src/routes/users.py.hbs
+++ b/templates/other/features/authentication/apps/api/src/routes/users.py.hbs
@@ -1,0 +1,9 @@
+from fastapi import APIRouter, Depends
+from ..auth.oauth import oauth2_scheme
+from ..models.user import User
+
+router = APIRouter(prefix="/users")
+
+@router.get("/me", response_model=User)
+async def me(token: str = Depends(oauth2_scheme)):
+    return User(username="admin")

--- a/templates/other/features/authentication/apps/web/src/components/auth/LoginForm.tsx.hbs
+++ b/templates/other/features/authentication/apps/web/src/components/auth/LoginForm.tsx.hbs
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+
+export default function LoginForm() {
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <form onSubmit={e => {e.preventDefault(); login(username, password);}} className="space-y-2">
+      <input value={username} onChange={e=>setUsername(e.target.value)} placeholder="Username" className="border px-2 py-1" />
+      <input value={password} onChange={e=>setPassword(e.target.value)} type="password" placeholder="Password" className="border px-2 py-1" />
+      <button type="submit" className="px-3 py-1 bg-blue-500 text-white">Login</button>
+    </form>
+  );
+}

--- a/templates/other/features/authentication/apps/web/src/components/auth/ProtectedRoute.tsx.hbs
+++ b/templates/other/features/authentication/apps/web/src/components/auth/ProtectedRoute.tsx.hbs
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+import { Navigate } from 'react-router-dom';
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { token } = useAuth();
+  return token ? <>{children}</> : <Navigate to="/login" />;
+}

--- a/templates/other/features/authentication/apps/web/src/components/auth/RegisterForm.tsx.hbs
+++ b/templates/other/features/authentication/apps/web/src/components/auth/RegisterForm.tsx.hbs
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export default function RegisterForm() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const register = async () => {
+    await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+  };
+
+  return (
+    <form onSubmit={e => {e.preventDefault(); register();}} className="space-y-2">
+      <input value={username} onChange={e=>setUsername(e.target.value)} placeholder="Username" className="border px-2 py-1" />
+      <input value={password} onChange={e=>setPassword(e.target.value)} type="password" placeholder="Password" className="border px-2 py-1" />
+      <button type="submit" className="px-3 py-1 bg-green-500 text-white">Register</button>
+    </form>
+  );
+}

--- a/templates/other/features/authentication/apps/web/src/components/auth/UserProfile.tsx.hbs
+++ b/templates/other/features/authentication/apps/web/src/components/auth/UserProfile.tsx.hbs
@@ -1,0 +1,12 @@
+import { useUser } from '../../hooks/useUser';
+
+export default function UserProfile() {
+  const { data } = useUser();
+  if (!data) return null;
+  return (
+    <div className="space-y-1">
+      <div>{data.username}</div>
+      {data.email && <div className="text-sm text-gray-500">{data.email}</div>}
+    </div>
+  );
+}

--- a/templates/other/features/authentication/apps/web/src/hooks/useAuth.ts.hbs
+++ b/templates/other/features/authentication/apps/web/src/hooks/useAuth.ts.hbs
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocalStorage } from 'usehooks-ts';
+
+type AuthContextType = {
+  token: string | null;
+  login: (u: string, p: string) => Promise<void>;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType>(null as any);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useLocalStorage<string | null>('token', null);
+  const navigate = useNavigate();
+
+  const login = async (username: string, password: string) => {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.access_token);
+      navigate('/');
+    }
+  };
+
+  const logout = () => {
+    setToken(null);
+    navigate('/login');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/templates/other/features/authentication/apps/web/src/hooks/useUser.ts.hbs
+++ b/templates/other/features/authentication/apps/web/src/hooks/useUser.ts.hbs
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from './useAuth';
+
+export function useUser() {
+  const { token } = useAuth();
+  return useQuery(['me'], async () => {
+    const res = await fetch('/api/users/me', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed');
+    return res.json();
+  }, { enabled: !!token });
+}

--- a/templates/other/features/authentication/apps/web/src/stores/authStore.ts.hbs
+++ b/templates/other/features/authentication/apps/web/src/stores/authStore.ts.hbs
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  token: string | null;
+  setToken: (t: string | null) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  token: null,
+  setToken: (t) => set({ token: t })
+}));

--- a/templates/other/features/real-time/apps/api/src/routes/websocket.py.hbs
+++ b/templates/other/features/real-time/apps/api/src/routes/websocket.py.hbs
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from ..websocket.manager import ConnectionManager
+
+router = APIRouter()
+manager = ConnectionManager()
+
+@router.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await manager.connect(ws)
+    try:
+        while True:
+            data = await ws.receive_text()
+            await manager.broadcast(data)
+    except WebSocketDisconnect:
+        manager.disconnect(ws)

--- a/templates/other/features/real-time/apps/api/src/websocket/__init__.py.hbs
+++ b/templates/other/features/real-time/apps/api/src/websocket/__init__.py.hbs
@@ -1,0 +1,1 @@
+# WebSocket utilities

--- a/templates/other/features/real-time/apps/api/src/websocket/handlers.py.hbs
+++ b/templates/other/features/real-time/apps/api/src/websocket/handlers.py.hbs
@@ -1,0 +1,6 @@
+from .manager import ConnectionManager
+
+manager = ConnectionManager()
+
+async def send_update(message: str):
+    await manager.broadcast(message)

--- a/templates/other/features/real-time/apps/api/src/websocket/manager.py.hbs
+++ b/templates/other/features/real-time/apps/api/src/websocket/manager.py.hbs
@@ -1,0 +1,18 @@
+from typing import List
+from fastapi import WebSocket
+
+class ConnectionManager:
+    def __init__(self):
+        self.active: List[WebSocket] = []
+
+    async def connect(self, ws: WebSocket):
+        await ws.accept()
+        self.active.append(ws)
+
+    def disconnect(self, ws: WebSocket):
+        if ws in self.active:
+            self.active.remove(ws)
+
+    async def broadcast(self, message: str):
+        for ws in list(self.active):
+            await ws.send_text(message)

--- a/templates/other/features/real-time/apps/web/src/components/realtime/ConnectionStatus.tsx.hbs
+++ b/templates/other/features/real-time/apps/web/src/components/realtime/ConnectionStatus.tsx.hbs
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export default function ConnectionStatus() {
+  const [online, setOnline] = useState(false);
+
+  useEffect(() => {
+    const ws = new WebSocket(`ws://${window.location.host}/ws`);
+    ws.onopen = () => setOnline(true);
+    ws.onclose = () => setOnline(false);
+    return () => ws.close();
+  }, []);
+
+  return <span>{online ? 'Online' : 'Offline'}</span>;
+}

--- a/templates/other/features/real-time/apps/web/src/components/realtime/LiveUpdates.tsx.hbs
+++ b/templates/other/features/real-time/apps/web/src/components/realtime/LiveUpdates.tsx.hbs
@@ -1,0 +1,10 @@
+import { useRealtime } from '../../hooks/useRealtime';
+
+export default function LiveUpdates() {
+  const messages = useRealtime();
+  return (
+    <ul className="space-y-1">
+      {messages.map((m, i) => <li key={i}>{m}</li>)}
+    </ul>
+  );
+}

--- a/templates/other/features/real-time/apps/web/src/hooks/useRealtime.ts.hbs
+++ b/templates/other/features/real-time/apps/web/src/hooks/useRealtime.ts.hbs
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import { useWebSocket } from './useWebSocket';
+
+export function useRealtime() {
+  const [messages, setMessages] = useState<string[]>([]);
+  useWebSocket(`ws://${window.location.host}/ws`, msg => setMessages(m => [...m, msg]));
+  return messages;
+}

--- a/templates/other/features/real-time/apps/web/src/hooks/useWebSocket.ts.hbs
+++ b/templates/other/features/real-time/apps/web/src/hooks/useWebSocket.ts.hbs
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export function useWebSocket(url: string, onMessage: (msg: string) => void) {
+  const wsRef = useRef<WebSocket>();
+
+  useEffect(() => {
+    wsRef.current = new WebSocket(url);
+    wsRef.current.onmessage = (e) => onMessage(e.data);
+    return () => wsRef.current?.close();
+  }, [url, onMessage]);
+}


### PR DESCRIPTION
## Summary
- implement AI feature template with API, hooks and components
- implement Authentication feature template with backend and frontend files
- implement Real-time feature template with websocket utilities

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm run validate:templates` *(fails: MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6844dc7ea5348323af896500cc9185b2