### PR TITLE
Add CMS template files

### DIFF
--- a/templates/cms/apps/api/src/cms/__init__.py.hbs
+++ b/templates/cms/apps/api/src/cms/__init__.py.hbs
@@ -1,0 +1,2 @@
+"""CMS utilities"""
+

--- a/templates/cms/apps/api/src/cms/publishing.py.hbs
+++ b/templates/cms/apps/api/src/cms/publishing.py.hbs
@@ -1,0 +1,8 @@
+"""Simple publishing workflow"""
+
+from ..models.page import Page
+from ..models.content import Content
+
+async def publish_page(page: Page, content: Content) -> None:
+    # TODO: implement publishing logic
+    pass

--- a/templates/cms/apps/api/src/cms/workflow.py.hbs
+++ b/templates/cms/apps/api/src/cms/workflow.py.hbs
@@ -1,0 +1,5 @@
+"""Editorial workflow utilities"""
+
+async def start_review(item_id: str):
+    # TODO: implement workflow logic
+    return True

--- a/templates/cms/apps/api/src/models/category.py.hbs
+++ b/templates/cms/apps/api/src/models/category.py.hbs
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Category(BaseModel):
+    id: str
+    name: str

--- a/templates/cms/apps/api/src/models/content.py.hbs
+++ b/templates/cms/apps/api/src/models/content.py.hbs
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Content(BaseModel):
+    id: str
+    title: str
+    body: str
+    category_id: Optional[str] = None

--- a/templates/cms/apps/api/src/models/media.py.hbs
+++ b/templates/cms/apps/api/src/models/media.py.hbs
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class Media(BaseModel):
+    id: str
+    filename: str
+    url: str

--- a/templates/cms/apps/api/src/models/page.py.hbs
+++ b/templates/cms/apps/api/src/models/page.py.hbs
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Page(BaseModel):
+    id: str
+    title: str
+    slug: str
+    content_id: Optional[str] = None

--- a/templates/cms/apps/api/src/routes/admin.py.hbs
+++ b/templates/cms/apps/api/src/routes/admin.py.hbs
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+@router.get("/dashboard")
+async def dashboard():
+    return {"status": "ok"}

--- a/templates/cms/apps/api/src/routes/content.py.hbs
+++ b/templates/cms/apps/api/src/routes/content.py.hbs
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+
+from ..models.content import Content
+from ..models.page import Page
+
+router = APIRouter(prefix="/content", tags=["content"])
+
+fake_db: List[Content] = []
+
+@router.get("/", response_model=List[Content])
+async def list_content():
+    return fake_db
+
+@router.post("/", response_model=Content)
+async def create_content(content: Content):
+    fake_db.append(content)
+    return content
+
+@router.get("/{content_id}", response_model=Content)
+async def get_content(content_id: str):
+    for item in fake_db:
+        if item.id == content_id:
+            return item
+    raise HTTPException(status_code=404, detail="Content not found")

--- a/templates/cms/apps/api/src/routes/media.py.hbs
+++ b/templates/cms/apps/api/src/routes/media.py.hbs
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, UploadFile, File
+from ..storage.local import LocalStorage
+
+router = APIRouter(prefix="/media", tags=["media"])
+
+storage = LocalStorage()
+
+@router.post("/upload")
+async def upload_file(file: UploadFile = File(...)):
+    url = await storage.save_file(file)
+    return {"url": url}

--- a/templates/cms/apps/api/src/routes/pages.py.hbs
+++ b/templates/cms/apps/api/src/routes/pages.py.hbs
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from ..models.page import Page
+
+router = APIRouter(prefix="/pages", tags=["pages"])
+
+@router.get("/", response_model=list[Page])
+async def list_pages():
+    return []

--- a/templates/cms/apps/api/src/storage/__init__.py.hbs
+++ b/templates/cms/apps/api/src/storage/__init__.py.hbs
@@ -1,0 +1,4 @@
+from .local import LocalStorage
+from .cloud import CloudStorage
+
+__all__ = ["LocalStorage", "CloudStorage"]

--- a/templates/cms/apps/api/src/storage/cloud.py.hbs
+++ b/templates/cms/apps/api/src/storage/cloud.py.hbs
@@ -1,0 +1,4 @@
+class CloudStorage:
+    async def save_file(self, file):
+        # TODO: integrate with cloud provider
+        return "https://example.com/" + file.filename

--- a/templates/cms/apps/api/src/storage/local.py.hbs
+++ b/templates/cms/apps/api/src/storage/local.py.hbs
@@ -1,0 +1,12 @@
+import os
+from fastapi import UploadFile
+
+class LocalStorage:
+    base_path = "uploads"
+
+    async def save_file(self, file: UploadFile) -> str:
+        os.makedirs(self.base_path, exist_ok=True)
+        path = os.path.join(self.base_path, file.filename)
+        with open(path, "wb") as f:
+            f.write(await file.read())
+        return path

--- a/templates/cms/apps/web/src/components/admin/AdminDashboard.tsx.hbs
+++ b/templates/cms/apps/web/src/components/admin/AdminDashboard.tsx.hbs
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AdminDashboard() {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Admin Dashboard</h2>
+      <p>Manage content, users and roles.</p>
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/admin/RoleManager.tsx.hbs
+++ b/templates/cms/apps/web/src/components/admin/RoleManager.tsx.hbs
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function RoleManager() {
+  return (
+    <div>
+      <h3 className="text-xl font-semibold mb-2">Role Management</h3>
+      <p>TODO: Implement role management UI</p>
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/admin/UserManager.tsx.hbs
+++ b/templates/cms/apps/web/src/components/admin/UserManager.tsx.hbs
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function UserManager() {
+  return (
+    <div>
+      <h3 className="text-xl font-semibold mb-2">User Management</h3>
+      <p>TODO: Implement user management UI</p>
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/content/ContentCard.tsx.hbs
+++ b/templates/cms/apps/web/src/components/content/ContentCard.tsx.hbs
@@ -1,0 +1,11 @@
+import React from 'react';
+import type { Content } from '../../stores/contentStore';
+
+export default function ContentCard({ content }: { content: Content }) {
+  return (
+    <div className="border rounded p-4 shadow">
+      <h3 className="text-lg font-semibold mb-2">{content.title}</h3>
+      <div className="text-sm text-gray-600" dangerouslySetInnerHTML={{ __html: content.body }} />
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/content/ContentForm.tsx.hbs
+++ b/templates/cms/apps/web/src/components/content/ContentForm.tsx.hbs
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import RichTextEditor from '../editor/RichTextEditor';
+import MediaUploader from '../editor/MediaUploader';
+import type { Content } from '../../stores/contentStore';
+
+interface Props {
+  initial?: Content;
+  onSave: (content: Content) => void;
+}
+
+export default function ContentForm({ initial, onSave }: Props) {
+  const [title, setTitle] = useState(initial?.title || '');
+  const [body, setBody] = useState(initial?.body || '');
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        onSave({ id: initial?.id || Date.now().toString(), title, body });
+      }}
+      className="space-y-4"
+    >
+      <input
+        className="border rounded px-3 py-2 w-full"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="Title"
+      />
+      <RichTextEditor content={body} onChange={setBody} />
+      <MediaUploader onUpload={file => console.log('upload', file)} />
+      <button className="px-4 py-2 bg-green-600 text-white rounded" type="submit">
+        Save
+      </button>
+    </form>
+  );
+}

--- a/templates/cms/apps/web/src/components/content/ContentList.tsx.hbs
+++ b/templates/cms/apps/web/src/components/content/ContentList.tsx.hbs
@@ -1,0 +1,13 @@
+import React from 'react';
+import ContentCard from './ContentCard';
+import type { Content } from '../../stores/contentStore';
+
+export default function ContentList({ items }: { items: Content[] }) {
+  return (
+    <div className="space-y-4">
+      {items.map(item => (
+        <ContentCard key={item.id} content={item} />
+      ))}
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/editor/ContentPreview.tsx.hbs
+++ b/templates/cms/apps/web/src/components/editor/ContentPreview.tsx.hbs
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function ContentPreview({ html }: { html: string }) {
+  return (
+    <div className="prose" dangerouslySetInnerHTML={{ __html: html }} />
+  );
+}

--- a/templates/cms/apps/web/src/components/editor/MediaUploader.tsx.hbs
+++ b/templates/cms/apps/web/src/components/editor/MediaUploader.tsx.hbs
@@ -1,0 +1,29 @@
+import React, { useRef } from 'react';
+
+interface Props {
+  onUpload: (file: File) => void;
+}
+
+export default function MediaUploader({ onUpload }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="file"
+        className="hidden"
+        onChange={e => {
+          const file = e.target.files?.[0];
+          if (file) onUpload(file);
+        }}
+      />
+      <button
+        className="px-3 py-1 bg-blue-600 text-white rounded"
+        onClick={() => inputRef.current?.click()}
+      >
+        Upload Media
+      </button>
+    </div>
+  );
+}

--- a/templates/cms/apps/web/src/components/editor/RichTextEditor.tsx.hbs
+++ b/templates/cms/apps/web/src/components/editor/RichTextEditor.tsx.hbs
@@ -1,0 +1,15 @@
+import React from 'react';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
+export default function RichTextEditor({ content, onChange }: { content: string; onChange: (html: string) => void }) {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content,
+    onUpdate({ editor }) {
+      onChange(editor.getHTML());
+    },
+  });
+
+  return <EditorContent editor={editor} />;
+}

--- a/templates/cms/apps/web/src/stores/adminStore.ts.hbs
+++ b/templates/cms/apps/web/src/stores/adminStore.ts.hbs
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface AdminState {
+  users: string[];
+  roles: string[];
+  addUser: (name: string) => void;
+  addRole: (role: string) => void;
+}
+
+export const useAdminStore = create<AdminState>((set) => ({
+  users: [],
+  roles: [],
+  addUser: (name) => set((state) => ({ users: [...state.users, name] })),
+  addRole: (role) => set((state) => ({ roles: [...state.roles, role] })),
+}));

--- a/templates/cms/apps/web/src/stores/contentStore.ts.hbs
+++ b/templates/cms/apps/web/src/stores/contentStore.ts.hbs
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+export interface Content {
+  id: string;
+  title: string;
+  body: string;
+}
+
+interface ContentState {
+  items: Content[];
+  add: (content: Content) => void;
+}
+
+export const useContentStore = create<ContentState>((set) => ({
+  items: [],
+  add: (content) => set((state) => ({ items: [...state.items, content] })),
+}));

--- a/templates/cms/apps/web/src/stores/mediaStore.ts.hbs
+++ b/templates/cms/apps/web/src/stores/mediaStore.ts.hbs
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+export interface Media {
+  id: string;
+  url: string;
+  filename: string;
+}
+
+interface MediaState {
+  files: Media[];
+  add: (file: Media) => void;
+}
+
+export const useMediaStore = create<MediaState>((set) => ({
+  files: [],
+  add: (file) => set((state) => ({ files: [...state.files, file] })),
+}));


### PR DESCRIPTION
## Summary
- implement CMS template directories per spec
- add example editor components, content management components, and stores
- add FastAPI routes, models, and storage utilities for CMS API

## Testing
- `pnpm run validate:templates` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6844dfa6ed248323beb689a324177a31