### PR TITLE
Implement basic type sync system

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,51 +1,47 @@
 // packages/cli/src/cli.ts
-import { Command } from "commander";
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
-import { createCreateCommand } from "./commands/create.js";
-import { createDevCommand } from "./commands/dev.js";
-import { createBuildCommand } from "./commands/build.js";
-import { createGenerateCommand } from "./commands/generate.js";
-import { createValidateCommands } from "./commands/validate";
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { createCreateCommand } from './commands/create.js';
+import { createDevCommand } from './commands/dev.js';
+import { createBuildCommand } from './commands/build.js';
+import { createGenerateCommand } from './commands/generate.js';
+import { createValidateCommands } from './commands/validate';
+import { registerTypeCommands } from './commands/types/index.js';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const packageJson = JSON.parse(
-  readFileSync(join(__dirname, "..", "package.json"), "utf-8")
-);
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
 export function createCLI(): Command {
   const program = new Command();
-
   program
-    .name("farm")
-    .description("FARM Stack Framework - AI-first full-stack development")
+    .name('farm')
+    .description('FARM Stack Framework - AI-first full-stack development')
     .version(packageJson.version)
-    .helpOption("-h, --help", "Display help for command")
-    .addHelpCommand("help [command]", "Display help for command");
+    .helpOption('-h, --help', 'Display help for command')
+    .addHelpCommand('help [command]', 'Display help for command');
 
-  // Global options
   program
-    .option("-v, --verbose", "Enable verbose logging")
-    .option("--no-color", "Disable colored output")
-    .option("--config <path>", "Path to configuration file");
+    .option('-v, --verbose', 'Enable verbose logging')
+    .option('--no-color', 'Disable colored output')
+    .option('--config <path>', 'Path to configuration file');
 
-  // Add your existing commands
-  program.addCommand(createCreateCommand()); // We need to create this
-  program.addCommand(createDevCommand()); // From your dev.ts
-  program.addCommand(createBuildCommand()); // We need to update this
-  program.addCommand(createGenerateCommand()); // We need to update this
-  program.addCommand(createValidateCommands()); // We need to update this
+  program.addCommand(createCreateCommand());
+  program.addCommand(createDevCommand());
+  program.addCommand(createBuildCommand());
+  program.addCommand(createGenerateCommand());
+  program.addCommand(createValidateCommands());
+  registerTypeCommands(program);
 
-  // Add version command as alias
   program
-    .command("version")
-    .description("Show version information")
+    .command('version')
+    .description('Show version information')
     .action(() => {
       console.log(`FARM CLI v${packageJson.version}`);
     });
 
-  // Handle unknown commands
-  program.on("command:*", (operands) => {
+  program.on('command:*', (operands) => {
     console.error(`\n❌ Unknown command: ${operands[0]}`);
     console.log('\nRun "farm --help" to see available commands.\n');
     process.exit(1);
@@ -55,13 +51,12 @@ export function createCLI(): Command {
 }
 
 export function setupErrorHandling() {
-  process.on("unhandledRejection", (reason, promise) => {
-    console.error("❌ Unhandled Rejection at:", promise, "reason:", reason);
+  process.on('unhandledRejection', (reason, promise) => {
+    console.error('❌ Unhandled Rejection at:', promise, 'reason:', reason);
     process.exit(1);
   });
-
-  process.on("uncaughtException", (error) => {
-    console.error("❌ Uncaught Exception:", error);
+  process.on('uncaughtException', (error) => {
+    console.error('❌ Uncaught Exception:', error);
     process.exit(1);
   });
 }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,5 +1,6 @@
 // Command exports
-export { createProject } from "./create.js";
-export { createDevCommand } from "./dev.js";
-export { createGenerateCommand } from "./generate.js";
-export { createBuildCommand } from "./build.js";
+export { createProject } from './create.js';
+export { createDevCommand } from './dev.js';
+export { createGenerateCommand } from './generate.js';
+export { createBuildCommand } from './build.js';
+export { registerTypeCommands } from './types/index.js';

--- a/packages/cli/src/commands/types/check.ts
+++ b/packages/cli/src/commands/types/check.ts
@@ -1,0 +1,32 @@
+// packages/cli/src/commands/types/check.ts
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { TypeSyncOrchestrator, TypeDiffer } from '@farm/core/codegen/type-sync';
+import fs from 'fs-extra';
+
+export function createTypeCheckCommand(): Command {
+  const cmd = new Command('types:check');
+  cmd
+    .description('Validate committed type definitions are up to date')
+    .action(async () => {
+      console.log(chalk.blue('🔍 Checking type synchronization...'));
+      const tempDir = '.farm/temp/type-check';
+      const orchestrator = new TypeSyncOrchestrator();
+      await orchestrator.initialize({
+        apiUrl: 'http://localhost:8000',
+        outputDir: tempDir,
+        features: { client: true, hooks: true, streaming: true },
+      });
+      await orchestrator.syncOnce();
+      const differ = new TypeDiffer();
+      const diffs = await differ.compareDirectories('.farm/types/generated', tempDir);
+      await fs.remove(tempDir);
+      if (diffs.length > 0) {
+        console.error(chalk.red('❌ Type definitions are out of sync!'));
+        diffs.forEach(d => console.error(`  - ${d.file}: ${d.message}`));
+        process.exit(1);
+      }
+      console.log(chalk.green('✅ Type definitions are in sync'));
+    });
+  return cmd;
+}

--- a/packages/cli/src/commands/types/index.ts
+++ b/packages/cli/src/commands/types/index.ts
@@ -1,0 +1,9 @@
+// packages/cli/src/commands/types/index.ts
+import { Command } from 'commander';
+import { createTypeSyncCommand } from './sync';
+import { createTypeCheckCommand } from './check';
+
+export function registerTypeCommands(program: Command) {
+  program.addCommand(createTypeSyncCommand());
+  program.addCommand(createTypeCheckCommand());
+}

--- a/packages/cli/src/commands/types/sync.ts
+++ b/packages/cli/src/commands/types/sync.ts
@@ -1,0 +1,37 @@
+// packages/cli/src/commands/types/sync.ts
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { TypeSyncOrchestrator, SyncOptions, TypeSyncWatcher } from '@farm/core/codegen/type-sync';
+
+export function createTypeSyncCommand(): Command {
+  const cmd = new Command('types:sync');
+  cmd
+    .description('Synchronize TypeScript types from FastAPI models')
+    .option('-w, --watch', 'Watch for changes and auto-regenerate')
+    .option('--no-client', 'Skip API client generation')
+    .option('--no-hooks', 'Skip React hooks generation')
+    .option('--output <path>', 'Custom output directory', '.farm/types/generated')
+    .action(async opts => {
+      const orchestrator = new TypeSyncOrchestrator();
+      const options: SyncOptions = {
+        apiUrl: 'http://localhost:8000',
+        outputDir: opts.output,
+        features: {
+          client: opts.client !== false,
+          hooks: opts.hooks !== false,
+          streaming: true,
+        },
+      };
+      await orchestrator.initialize(options);
+      if (opts.watch) {
+        console.log(chalk.blue('🔄 Starting type sync in watch mode...'));
+        const watcher = new TypeSyncWatcher(orchestrator);
+        await watcher.start();
+      } else {
+        console.log(chalk.blue('🔄 Generating types...'));
+        const result = await orchestrator.syncOnce();
+        console.log(chalk.green(`✅ Generated ${result.filesGenerated} files`));
+      }
+    });
+  return cmd;
+}

--- a/packages/core/src/codegen/index.ts
+++ b/packages/core/src/codegen/index.ts
@@ -1,0 +1,3 @@
+// packages/core/src/codegen/index.ts
+export * from './generator';
+export * from './type-sync';

--- a/packages/core/src/codegen/type-sync/__tests__/orchestrator.test.ts
+++ b/packages/core/src/codegen/type-sync/__tests__/orchestrator.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { TypeSyncOrchestrator } from '../orchestrator';
+
+describe('TypeSyncOrchestrator', () => {
+  it('initializes without error', async () => {
+    const orchestrator = new TypeSyncOrchestrator();
+    await orchestrator.initialize({
+      apiUrl: 'http://localhost:8000',
+      outputDir: '.farm/test',
+      features: { client: true, hooks: true, streaming: false },
+    });
+    expect(true).toBe(true);
+  });
+});

--- a/packages/core/src/codegen/type-sync/cache.ts
+++ b/packages/core/src/codegen/type-sync/cache.ts
@@ -1,0 +1,35 @@
+// packages/core/src/codegen/type-sync/cache.ts
+import fs from 'fs-extra';
+import path from 'path';
+import crypto from 'crypto';
+
+interface CacheEntry {
+  schema: any;
+  results: any;
+}
+
+export class GenerationCache {
+  constructor(private baseDir: string) {}
+
+  private entryPath(hash: string) {
+    return path.join(this.baseDir, `${hash}.json`);
+  }
+
+  hashSchema(schema: any): string {
+    return crypto.createHash('sha256').update(JSON.stringify(schema)).digest('hex');
+  }
+
+  async get(hash: string): Promise<CacheEntry | null> {
+    const file = this.entryPath(hash);
+    try {
+      return await fs.readJson(file);
+    } catch {
+      return null;
+    }
+  }
+
+  async set(hash: string, entry: CacheEntry): Promise<void> {
+    await fs.ensureDir(this.baseDir);
+    await fs.writeJson(this.entryPath(hash), entry);
+  }
+}

--- a/packages/core/src/codegen/type-sync/differ.ts
+++ b/packages/core/src/codegen/type-sync/differ.ts
@@ -1,0 +1,31 @@
+// packages/core/src/codegen/type-sync/differ.ts
+import fs from 'fs-extra';
+import path from 'path';
+import { diffLines } from 'diff';
+
+export class TypeDiffer {
+  hasSchemaChanges(prev: any, next: any): boolean {
+    return JSON.stringify(prev) !== JSON.stringify(next);
+  }
+
+  async compareDirectories(dirA: string, dirB: string) {
+    const diffs: { file: string; message: string }[] = [];
+    const filesA = await fs.readdir(dirA);
+    for (const file of filesA) {
+      const aPath = path.join(dirA, file);
+      const bPath = path.join(dirB, file);
+      if (!fs.existsSync(bPath)) {
+        diffs.push({ file, message: 'missing in B' });
+        continue;
+      }
+      const [aContent, bContent] = await Promise.all([
+        fs.readFile(aPath, 'utf-8'),
+        fs.readFile(bPath, 'utf-8'),
+      ]);
+      if (diffLines(aContent, bContent).some(d => d.added || d.removed)) {
+        diffs.push({ file, message: 'content differs' });
+      }
+    }
+    return diffs;
+  }
+}

--- a/packages/core/src/codegen/type-sync/index.ts
+++ b/packages/core/src/codegen/type-sync/index.ts
@@ -1,0 +1,6 @@
+// packages/core/src/codegen/type-sync/index.ts
+export { TypeSyncOrchestrator } from './orchestrator';
+export { TypeSyncWatcher } from './watcher';
+export { GenerationCache } from './cache';
+export { TypeDiffer } from './differ';
+export type { SyncOptions, SyncResult } from './orchestrator';

--- a/packages/core/src/codegen/type-sync/orchestrator.ts
+++ b/packages/core/src/codegen/type-sync/orchestrator.ts
@@ -1,0 +1,93 @@
+// packages/core/src/codegen/type-sync/orchestrator.ts
+import { OpenAPIExtractor } from '../../../tools/codegen/openapi-extractor';
+import { TypeScriptGenerator } from '../../../tools/codegen/typescript-generator';
+import { APIClientGenerator } from '../../../tools/codegen/api-client-generator';
+import { ReactHookGenerator } from '../../../tools/codegen/react-hook-generator';
+import { AIHookGenerator } from '../../../tools/codegen/ai-hook-generator';
+import { GenerationCache } from './cache';
+import { TypeDiffer } from './differ';
+import fs from 'fs-extra';
+import path from 'path';
+import type { OpenAPISchema } from '@farm/types';
+
+export interface SyncOptions {
+  apiUrl: string;
+  outputDir: string;
+  features: {
+    client: boolean;
+    hooks: boolean;
+    streaming: boolean;
+  };
+}
+
+export interface SyncResult {
+  filesGenerated: number;
+  fromCache: boolean;
+  artifacts?: string[];
+}
+
+interface Generator {
+  generate: (schema: OpenAPISchema, opts: any) => Promise<{ path: string }>; // minimal
+}
+
+export class TypeSyncOrchestrator {
+  private extractor = new OpenAPIExtractor();
+  private cache = new GenerationCache('.farm/cache/types');
+  private differ = new TypeDiffer();
+  private generators = new Map<string, Generator>();
+  private config: SyncOptions | null = null;
+
+  constructor() {
+    this.initializeGenerators();
+  }
+
+  private initializeGenerators() {
+    this.generators.set('types', new TypeScriptGenerator() as unknown as Generator);
+    this.generators.set('client', new APIClientGenerator() as unknown as Generator);
+    this.generators.set('hooks', new ReactHookGenerator() as unknown as Generator);
+    this.generators.set('ai-hooks', new AIHookGenerator() as unknown as Generator);
+  }
+
+  async initialize(config: SyncOptions) {
+    this.config = config;
+    await fs.ensureDir(config.outputDir);
+  }
+
+  private isFeatureEnabled(genType: string): boolean {
+    if (!this.config) return false;
+    if (genType === 'client') return this.config.features.client;
+    if (genType === 'hooks' || genType === 'ai-hooks') return this.config.features.hooks;
+    return true;
+  }
+
+  async syncOnce(opts?: Partial<SyncOptions>): Promise<SyncResult> {
+    if (!this.config) throw new Error('Orchestrator not initialized');
+    const config = { ...this.config, ...opts } as SyncOptions;
+
+    const schema = await this.extractor.extractFromFastAPI('.', path.join(config.outputDir, 'openapi.json'))
+      .then(() => fs.readJson(path.join(config.outputDir, 'openapi.json')));
+
+    const schemaHash = this.cache.hashSchema(schema);
+    const cached = await this.cache.get(schemaHash);
+    if (cached && !this.differ.hasSchemaChanges(cached.schema, schema)) {
+      return { filesGenerated: 0, fromCache: true };
+    }
+
+    const results = await this.generateArtifacts(schema, config.outputDir);
+    await this.cache.set(schemaHash, { schema, results });
+    return { filesGenerated: results.length, fromCache: false, artifacts: results.map(r => r.path) };
+  }
+
+  private async generateArtifacts(schema: OpenAPISchema, outputDir: string) {
+    const results: { path: string }[] = [];
+    const order = ['types', 'client', 'hooks', 'ai-hooks'];
+    for (const type of order) {
+      const generator = this.generators.get(type);
+      if (generator && this.isFeatureEnabled(type)) {
+        const result = await generator.generate(schema, { outputDir });
+        results.push(result);
+      }
+    }
+    return results;
+  }
+}

--- a/packages/core/src/codegen/type-sync/watcher.ts
+++ b/packages/core/src/codegen/type-sync/watcher.ts
@@ -1,0 +1,55 @@
+// packages/core/src/codegen/type-sync/watcher.ts
+import chokidar from 'chokidar';
+import fs from 'fs-extra';
+import { debounce } from 'lodash-es';
+import { TypeSyncOrchestrator } from './orchestrator';
+
+export class TypeSyncWatcher {
+  private watcher: chokidar.FSWatcher | null = null;
+  private syncInProgress = false;
+
+  constructor(private orchestrator: TypeSyncOrchestrator) {
+    this.handleChange = debounce(this.handleChange.bind(this), 500);
+  }
+
+  async start() {
+    this.watcher = chokidar.watch([
+      'apps/api/src/models/**/*.py',
+      'apps/api/src/routes/**/*.py',
+      'apps/api/src/schemas/**/*.py',
+      'apps/api/src/ai/models/**/*.py',
+    ], {
+      ignored: ['**/__pycache__/**', '**/*.pyc'],
+      ignoreInitial: true,
+    });
+    this.watcher.on('all', this.handleChange);
+    console.log('👀 Watching for Python model changes...');
+  }
+
+  async stop() {
+    await this.watcher?.close();
+  }
+
+  private async handleChange() {
+    if (this.syncInProgress) return;
+    console.log('🔄 Detected change, regenerating types...');
+    try {
+      this.syncInProgress = true;
+      const start = Date.now();
+      const result = await this.orchestrator.syncOnce();
+      const duration = Date.now() - start;
+      console.log(`✅ Types regenerated in ${duration}ms (${result.filesGenerated} files)`);
+      await this.notifyFrontend();
+    } catch (err) {
+      console.error('❌ Type regeneration failed:', err);
+    } finally {
+      this.syncInProgress = false;
+    }
+  }
+
+  private async notifyFrontend() {
+    const triggerPath = '.farm/types/generated/.timestamp';
+    await fs.ensureFile(triggerPath);
+    await fs.writeFile(triggerPath, Date.now().toString());
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeSyncOrchestrator with caching and diffing
- implement TypeSyncWatcher to regenerate on Python changes
- expose new type-sync API from core codegen
- add CLI `types:sync` and `types:check` commands
- register the type commands in CLI
- include a basic orchestrator test

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f333cfe8832393d20a2086e5a3af