### PR TITLE
Implement assistant UI integration command

### DIFF
--- a/docs/quickstart/chat-ui.mdx
+++ b/docs/quickstart/chat-ui.mdx
@@ -1,0 +1,18 @@
+---
+title: Using the Assistant UI
+---
+
+import { Note } from 'nextra/components'
+
+# Assistant UI Quickstart
+
+To scaffold the chat interface run:
+
+```bash
+farm add ui assistant
+```
+
+This installs the necessary `@assistant-ui` packages, updates Tailwind and generates a chat page under `apps/web/src/pages/AssistantChat.tsx`.
+
+Wrap your app with `<AssistantProvider>` and navigate to `/assistant` to start chatting.
+

--- a/examples/assistant-chat/README.md
+++ b/examples/assistant-chat/README.md
@@ -1,0 +1,9 @@
+# Assistant Chat Example
+
+After running `farm add ui assistant` in your project root, open `apps/web` and run:
+
+```bash
+pnpm dev
+```
+
+Visit http://localhost:3000/assistant to try the chat interface.

--- a/packages/cli/src/__tests__/add-ui.test.ts
+++ b/packages/cli/src/__tests__/add-ui.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { createAddUICommand } from '../commands/add-ui.js';
+import { Command } from 'commander';
+
+describe('add ui assistant command', () => {
+  it('registers subcommand', () => {
+    const program = new Command();
+    program.addCommand(createAddUICommand());
+    const add = program.commands.find(c => c.name() === 'add');
+    expect(add).toBeDefined();
+    const ui = add?.commands.find(c => c.name() === 'ui');
+    expect(ui).toBeDefined();
+    const assistant = ui?.commands.find(c => c.name() === 'assistant');
+    expect(assistant).toBeDefined();
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { createBuildCommand } from './commands/build.js';
 import { createGenerateCommand } from './commands/generate.js';
 import { createValidateCommands } from './commands/validate';
 import { registerTypeCommands } from './commands/types/index.js';
+import { createAddUICommand } from './commands/add-ui.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -31,6 +32,7 @@ export function createCLI(): Command {
   program.addCommand(createDevCommand());
   program.addCommand(createBuildCommand());
   program.addCommand(createGenerateCommand());
+  program.addCommand(createAddUICommand());
   program.addCommand(createValidateCommands());
   registerTypeCommands(program);
 

--- a/packages/cli/src/commands/add-ui.ts
+++ b/packages/cli/src/commands/add-ui.ts
@@ -1,0 +1,167 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import path from 'path';
+import fs from 'fs-extra';
+import { PackageInstaller } from '../utils/package-installer.js';
+import { logger } from '../utils/logger.js';
+
+interface AddUIOptions {
+  verbose?: boolean;
+  dryRun?: boolean;
+}
+
+export function createAddUICommand(): Command {
+  const addCmd = new Command('add');
+  const uiCmd = new Command('ui');
+  const assistantCmd = new Command('assistant');
+  assistantCmd
+    .alias('chat')
+    .description('Add Assistant UI integration')
+    .option('--dry-run', 'Run without writing files')
+    .option('-v, --verbose', 'Verbose output')
+    .action(async (options: AddUIOptions) => {
+      await addAssistantUI(options);
+    });
+
+  uiCmd.addCommand(assistantCmd);
+  addCmd.addCommand(uiCmd);
+  return addCmd;
+}
+
+async function addAssistantUI(options: AddUIOptions): Promise<void> {
+  try {
+    const projectRoot = process.cwd();
+    const packages = [
+      '@assistant-ui/react',
+      '@assistant-ui/react-tailwind',
+      '@assistant-ui/react-markdown',
+      'remark-gfm',
+    ];
+
+    const installer = new PackageInstaller();
+    for (const pkg of packages) {
+      const installed = await installer.getInstalledVersion(projectRoot, pkg);
+      if (installed) {
+        logger.info(`📦 ${pkg} already installed (v${installed})`);
+        continue;
+      }
+      if (!options.dryRun) {
+        await installer.addDependency(projectRoot, pkg);
+      }
+      logger.success(`Installed ${pkg}`);
+    }
+
+    const tailwindPath = path.join(projectRoot, 'apps/web/tailwind.config.ts');
+    await ensureTailwindPlugin(tailwindPath, options.dryRun);
+
+    await generateFile(
+      path.join(projectRoot, 'apps/web/src/providers/AssistantProvider.tsx'),
+      providerTemplate,
+      options.dryRun,
+    );
+    await generateFile(
+      path.join(projectRoot, 'apps/web/src/hooks/useFarmAssistant.ts'),
+      hookTemplate,
+      options.dryRun,
+    );
+    await generateFile(
+      path.join(projectRoot, 'apps/web/src/pages/AssistantChat.tsx'),
+      pageTemplate,
+      options.dryRun,
+    );
+
+    await generateFile(
+      path.join(projectRoot, 'apps/web/src/api/assistant.ts'),
+      proxyTemplate,
+      options.dryRun,
+    );
+
+    logger.success('Assistant UI added');
+  } catch (error) {
+    logger.error('Failed to add Assistant UI:', error);
+    process.exit(1);
+  }
+}
+
+async function ensureTailwindPlugin(filePath: string, dryRun = false) {
+  let content = '';
+  if (await fs.pathExists(filePath)) {
+    content = await fs.readFile(filePath, 'utf8');
+  } else {
+    content = `import { defineConfig } from 'tailwindcss/helpers';\n\nexport default defineConfig({\n  content: ['./index.html', './src/**/*.{ts,tsx}'],\n  theme: { extend: {} },\n  plugins: [],\n});\n`;
+  }
+
+  if (!content.includes("'@assistant-ui/react-tailwind'") && !content.includes('"@assistant-ui/react-tailwind"')) {
+    content = content.replace(/plugins:\s*\[/, match => `${match}\n    require('@assistant-ui/react-tailwind'),`);
+  }
+
+  if (!dryRun) {
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, content);
+  }
+  logger.success(`Updated ${path.relative(process.cwd(), filePath)}`);
+}
+
+async function generateFile(filePath: string, tpl: string, dryRun = false) {
+  if (await fs.pathExists(filePath)) {
+    logger.info(`Skipping existing ${path.relative(process.cwd(), filePath)}`);
+    return;
+  }
+  if (!dryRun) {
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, tpl);
+  }
+  logger.success(`Created ${path.relative(process.cwd(), filePath)}`);
+}
+
+const providerTemplate = `import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import type { ReactNode } from 'react';
+import { useFarmAssistantRuntime } from '../hooks/useFarmAssistant';
+
+export function AssistantProvider({ children }: { children: ReactNode }) {
+  const runtime = useFarmAssistantRuntime();
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+`;
+
+const hookTemplate = `import { useLocalRuntime } from '@assistant-ui/react';
+import { useAIChat } from '@farm/ai-hooks';
+
+export function useFarmAssistantRuntime() {
+  const farmChat = useAIChat();
+  return useLocalRuntime({
+    async onNew(message) {
+      const response = await farmChat.mutateAsync({
+        messages: [{ role: 'user', content: message.content }],
+      });
+      return {
+        id: response.id ?? Date.now().toString(),
+        role: 'assistant',
+        content: [{ type: 'text', text: response.content }],
+      };
+    },
+  });
+}
+`;
+
+const pageTemplate = `import { Thread } from '@assistant-ui/react';
+import { makeMarkdownText } from '@assistant-ui/react-markdown';
+
+const MarkdownText = makeMarkdownText();
+
+export default function AssistantChat() {
+  return (
+    <div className='h-screen flex flex-col bg-background'>
+      <Thread assistantMessage={{ components: { Text: MarkdownText } }} className='flex-1' />
+    </div>
+  );
+}
+`;
+
+const proxyTemplate = `import { createProxyMiddleware } from 'http-proxy-middleware';
+export default createProxyMiddleware('/api/assistant', {
+  target: 'http://localhost:8000/chat',
+  changeOrigin: true,
+});
+`;
+

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,3 +4,4 @@ export { createDevCommand } from './dev.js';
 export { createGenerateCommand } from './generate.js';
 export { createBuildCommand } from './build.js';
 export { registerTypeCommands } from './types/index.js';
+export { createAddUICommand } from './add-ui.js';


### PR DESCRIPTION
## Summary
- add `farm add ui assistant` CLI command
- generate AssistantProvider, hook and chat page
- create docs and example for quickstart
- expose new CLI command
- add tests for command registration

## Testing
- `pnpm install`
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_6845059e76dc83238c847f07d07fdf4e