### PR TITLE
Centralize template validator types

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,6 +30,9 @@ export type {
   TemplatePrompt,
   PromptChoice,
   TemplateContext,
+  TemplateConfig,
+  TestResult,
+  ValidationResult,
 } from "./templates.js";
 
 // Plugin types

--- a/packages/types/src/templates.ts
+++ b/packages/types/src/templates.ts
@@ -69,3 +69,45 @@ export interface TemplateContext {
   timestamp: string;
   farmVersion: string;
 }
+
+/**
+ * Basic template configuration used by the template validator
+ * and various tooling. This mirrors the structure previously
+ * defined locally in `tools/template-validator`.
+ */
+export interface TemplateConfig {
+  name: string;
+  template: string;
+  features: string[];
+  database: string;
+  ai?: {
+    providers: string[];
+    models: string[];
+  };
+  realtime?: boolean;
+  auth?: boolean;
+}
+
+/**
+ * Individual test case result for template validation.
+ */
+export interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+  duration?: number;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Overall validation result for a template configuration.
+ */
+export interface ValidationResult {
+  templateName: string;
+  configName: string;
+  success: boolean;
+  duration: number;
+  error?: string;
+  tests: TestResult[];
+  metadata?: Record<string, any>;
+}

--- a/tools/template-validator/src/cli.ts
+++ b/tools/template-validator/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // tools/template-validator/src/cli.ts
 import { Command } from "commander";
+import type { ValidationResult } from "@farm/types";
 import { TemplateValidator } from "./validator";
 import { ALL_CONFIGURATIONS } from "./configurations";
 

--- a/tools/template-validator/src/configurations.ts
+++ b/tools/template-validator/src/configurations.ts
@@ -1,5 +1,5 @@
 // tools/template-validator/src/configurations.ts
-import { TemplateConfig } from "./types";
+import type { TemplateConfig } from "@farm/types";
 
 export const AI_CHAT_CONFIGURATIONS: TemplateConfig[] = [
   {

--- a/tools/template-validator/src/types.ts
+++ b/tools/template-validator/src/types.ts
@@ -1,34 +1,5 @@
 // tools/template-validator/src/types.ts
-export interface TemplateConfig {
-  name: string;
-  template: string;
-  features: string[];
-  database: string;
-  ai?: {
-    providers: string[];
-    models: string[];
-  };
-  realtime?: boolean;
-  auth?: boolean;
-}
-
-export interface ValidationResult {
-  templateName: string;
-  configName: string;
-  success: boolean;
-  duration: number;
-  error?: string;
-  tests: TestResult[];
-  metadata?: Record<string, any>;
-}
-
-export interface TestResult {
-  name: string;
-  passed: boolean;
-  error?: string;
-  duration?: number;
-  metadata?: Record<string, any>;
-}
+import type { TemplateConfig, ValidationResult, TestResult } from "@farm/types";
 
 export interface ServiceProcess {
   name: string;

--- a/tools/template-validator/src/validator.ts
+++ b/tools/template-validator/src/validator.ts
@@ -2,7 +2,8 @@
 import { spawn } from "child_process";
 import { promises as fs } from "fs";
 import path from "path";
-import { TemplateConfig, ValidationResult, ProviderConfig } from "./types";
+import type { TemplateConfig, ValidationResult, TestResult } from "@farm/types";
+import type { ProviderConfig } from "./types";
 
 export class TemplateValidator {
   private tempDir: string;


### PR DESCRIPTION
## Summary
- add TemplateConfig, TestResult and ValidationResult to `@farm/types`
- re-export the new interfaces
- refactor template-validator to use shared types

## Testing
- `pnpm test:run` *(fails: vitest not found)*
- `pnpm type-check` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451c9a2998832389ab0903a011e193