### PR TITLE
Implement basic db scaffolding

### DIFF
--- a/packages/cli/src/__tests__/database.test.ts
+++ b/packages/cli/src/__tests__/database.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { createDatabaseCommands } from '../commands/database.js';
+import { Command } from 'commander';
+
+describe('database command', () => {
+  it('registers add subcommand', () => {
+    const program = new Command();
+    program.addCommand(createDatabaseCommands());
+    const db = program.commands.find(c => c.name() === 'database');
+    expect(db).toBeDefined();
+    const add = db?.commands.find(c => c.name() === 'add');
+    expect(add).toBeDefined();
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { createGenerateCommand } from './commands/generate.js';
 import { createValidateCommands } from './commands/validate';
 import { registerTypeCommands } from './commands/types/index.js';
 import { createAddUICommand } from './commands/add-ui.js';
+import { createDatabaseCommands } from './commands/database.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -33,6 +34,7 @@ export function createCLI(): Command {
   program.addCommand(createBuildCommand());
   program.addCommand(createGenerateCommand());
   program.addCommand(createAddUICommand());
+  program.addCommand(createDatabaseCommands());
   program.addCommand(createValidateCommands());
   registerTypeCommands(program);
 

--- a/packages/cli/src/commands/database.ts
+++ b/packages/cli/src/commands/database.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import { DatabaseSelector } from "../scaffolding/database-selector.js";
+import { DatabaseGenerator } from "../generators/database-generator.js";
+import { logger } from "../utils/logger.js";
+
+export function createDatabaseCommands(): Command {
+  const database = new Command("database");
+  database.alias("db");
+  database.description("Database management commands");
+
+  database
+    .command("add")
+    .description("Add database support to existing project")
+    .option("-t, --type <type>", "Database type (mongodb, postgresql)")
+    .action(async (opts) => {
+      await addDatabase(opts.type);
+    });
+
+  return database;
+}
+
+async function addDatabase(type: string): Promise<void> {
+  const selector = new DatabaseSelector();
+  const dbType = (type as any) || "mongodb";
+  try {
+    const provider = await selector.selectDatabase(dbType);
+    const generator = new DatabaseGenerator(provider);
+    await generator.generateDatabaseConfig(process.cwd());
+    logger.success(`Added ${dbType} support`);
+  } catch (err) {
+    logger.error(`Failed to add database: ${(err as Error).message}`);
+  }
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,3 +5,4 @@ export { createGenerateCommand } from './generate.js';
 export { createBuildCommand } from './build.js';
 export { registerTypeCommands } from './types/index.js';
 export { createAddUICommand } from './add-ui.js';
+export { createDatabaseCommands } from './database.js';

--- a/packages/cli/src/generators/database-generator.ts
+++ b/packages/cli/src/generators/database-generator.ts
@@ -1,0 +1,20 @@
+import path from "path";
+import fs from "fs-extra";
+import { TemplateProcessor } from "../template/processor.js";
+import { DatabaseProvider, DatabaseType } from "@farm/types";
+import { logger } from "../utils/logger.js";
+
+export class DatabaseGenerator {
+  constructor(
+    private provider: DatabaseProvider,
+    private processor: TemplateProcessor = new TemplateProcessor()
+  ) {}
+
+  async generateDatabaseConfig(projectPath: string): Promise<void> {
+    const { type } = this.provider;
+    logger.info(`Scaffolding database files for ${type}...`);
+
+    const templateDir = `base/database/${type}`;
+    await this.processor.processTemplate(templateDir, { database: this.provider }, projectPath);
+  }
+}

--- a/packages/cli/src/scaffolding/database-selector.ts
+++ b/packages/cli/src/scaffolding/database-selector.ts
@@ -1,0 +1,92 @@
+import { DatabaseProvider, DatabaseType } from "@farm/types";
+import { logger } from "../utils/logger.js";
+
+export class DatabaseSelector {
+  private providers: Map<DatabaseType, DatabaseProvider> = new Map();
+
+  constructor() {
+    this.initializeProviders();
+  }
+
+  private initializeProviders() {
+    const mongo: DatabaseProvider = {
+      type: "mongodb",
+      connectionUrl: "mongodb://farm:farm123@localhost:27017/farmapp",
+      dependencies: { python: ["beanie>=1.24.0", "motor>=3.3.2", "pymongo>=4.6.0"] },
+      dockerConfig: {
+        image: "mongo:7-jammy",
+        environment: {
+          MONGO_INITDB_ROOT_USERNAME: "farm",
+          MONGO_INITDB_ROOT_PASSWORD: "farm123",
+          MONGO_INITDB_DATABASE: "farmapp",
+        },
+        ports: ["27017:27017"],
+        volumes: ["mongodb_data:/data/db"],
+        healthCheck: {
+          test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"],
+          interval: "30s",
+          timeout: "10s",
+          retries: 3,
+        },
+      },
+      templateConfig: {
+        baseConfigFile: "database/mongodb.py",
+        modelBaseClass: "Document",
+        migrationSupport: false,
+        features: ["json", "arrays", "fulltext"],
+      },
+    };
+
+    const postgres: DatabaseProvider = {
+      type: "postgresql",
+      connectionUrl: "postgresql://farm:farm123@localhost:5432/farmapp",
+      dependencies: {
+        python: [
+          "sqlmodel>=0.0.14",
+          "asyncpg>=0.29.0",
+          "alembic>=1.13.0",
+          "psycopg2-binary>=2.9.9",
+        ],
+      },
+      dockerConfig: {
+        image: "postgres:16-alpine",
+        environment: {
+          POSTGRES_DB: "farmapp",
+          POSTGRES_USER: "farm",
+          POSTGRES_PASSWORD: "farm123",
+          PGDATA: "/var/lib/postgresql/data/pgdata",
+        },
+        ports: ["5432:5432"],
+        volumes: ["postgres_data:/var/lib/postgresql/data"],
+        healthCheck: {
+          test: ["CMD-SHELL", "pg_isready -U farm -d farmapp"],
+          interval: "30s",
+          timeout: "10s",
+          retries: 3,
+        },
+      },
+      templateConfig: {
+        baseConfigFile: "database/postgresql.py",
+        modelBaseClass: "SQLModel",
+        migrationSupport: true,
+        features: ["transactions", "relations", "json", "fulltext"],
+      },
+    };
+
+    this.providers.set("mongodb", mongo);
+    this.providers.set("postgresql", postgres);
+  }
+
+  getSupportedDatabases(): DatabaseType[] {
+    return Array.from(this.providers.keys());
+  }
+
+  async selectDatabase(type: DatabaseType): Promise<DatabaseProvider> {
+    const provider = this.providers.get(type);
+    if (!provider) {
+      throw new Error(`Unsupported database type: ${type}`);
+    }
+    logger.info(`Selected database provider: ${type}`);
+    return provider;
+  }
+}

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1,6 +1,7 @@
 /**
  * FARM Configuration Types
  */
+import type { DatabaseConfig } from "./database.js";
 
 export interface FarmConfig {
   // Project metadata
@@ -41,11 +42,6 @@ export type FeatureType =
   | "search"
   | "analytics";
 
-export interface DatabaseConfig {
-  type: "mongodb" | "postgresql" | "mysql" | "sqlite";
-  url: string;
-  options?: Record<string, any>;
-}
 
 export interface AIConfig {
   providers: {

--- a/packages/types/src/database.ts
+++ b/packages/types/src/database.ts
@@ -2,10 +2,77 @@
  * Database Integration Types
  */
 
+export type DatabaseType = "mongodb" | "postgresql" | "mysql" | "sqlite";
+
+export interface DatabaseOptions {
+  poolSize?: number;
+  timeout?: number;
+  ssl?: boolean;
+  replicaSet?: string;
+  authSource?: string;
+  schema?: string;
+  synchronize?: boolean;
+  logging?: boolean;
+}
+
+export interface MigrationConfig {
+  enabled: boolean;
+  directory: string;
+  tableName?: string;
+  collectionName?: string;
+}
+
 export interface DatabaseConnection {
-  type: "mongodb" | "postgresql" | "mysql" | "sqlite";
+  type: DatabaseType;
   url: string;
   options?: Record<string, any>;
+}
+
+export interface DatabaseConfig {
+  type: DatabaseType;
+  url: string;
+  options?: DatabaseOptions;
+  migrations?: MigrationConfig;
+}
+
+export interface DatabaseDependencies {
+  python: string[];
+  javascript?: string[];
+}
+
+export interface DockerServiceConfig {
+  image: string;
+  environment: Record<string, string>;
+  ports: string[];
+  volumes: string[];
+  healthCheck?: {
+    test: string[];
+    interval: string;
+    timeout: string;
+    retries: number;
+  };
+}
+
+export type DatabaseFeature =
+  | "transactions"
+  | "fulltext"
+  | "json"
+  | "arrays"
+  | "relations";
+
+export interface TemplateConfig {
+  baseConfigFile: string;
+  modelBaseClass: string;
+  migrationSupport: boolean;
+  features: DatabaseFeature[];
+}
+
+export interface DatabaseProvider {
+  type: DatabaseType;
+  connectionUrl: string;
+  dependencies: DatabaseDependencies;
+  dockerConfig: DockerServiceConfig;
+  templateConfig: TemplateConfig;
 }
 
 export interface DatabaseModel {

--- a/templates/base/database/mongodb/base.py.hbs
+++ b/templates/base/database/mongodb/base.py.hbs
@@ -1,0 +1,14 @@
+from beanie import Document
+from datetime import datetime
+from pydantic import Field
+
+class BaseDocument(Document):
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Settings:
+        use_revision = True
+
+    async def save(self, *args, **kwargs):
+        self.updated_at = datetime.utcnow()
+        return await super().save(*args, **kwargs)

--- a/templates/base/database/mongodb/database.py.hbs
+++ b/templates/base/database/mongodb/database.py.hbs
@@ -1,0 +1,21 @@
+from motor.motor_asyncio import AsyncIOMotorClient
+from beanie import init_beanie
+from typing import Optional
+
+class DatabaseManager:
+    client: Optional[AsyncIOMotorClient] = None
+
+    async def connect(self) -> None:
+        self.client = AsyncIOMotorClient("{{database.connectionUrl}}", serverSelectionTimeoutMS=5000)
+        await self.client.admin.command("ping")
+
+    async def close(self) -> None:
+        if self.client:
+            self.client.close()
+
+    async def init_models(self, models) -> None:
+        if not self.client:
+            return
+        await init_beanie(database=self.client.get_default_database(), document_models=models)
+
+db = DatabaseManager()

--- a/templates/base/database/postgresql/base.py.hbs
+++ b/templates/base/database/postgresql/base.py.hbs
@@ -1,0 +1,14 @@
+from sqlmodel import SQLModel, Field
+from datetime import datetime
+from typing import Optional
+import uuid
+
+class BaseModel(SQLModel):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+class UUIDBaseModel(SQLModel):
+    id: Optional[str] = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/templates/base/database/postgresql/database.py.hbs
+++ b/templates/base/database/postgresql/database.py.hbs
@@ -1,0 +1,31 @@
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from contextlib import asynccontextmanager
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "{{database.connectionUrl}}")
+
+engine = create_async_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+)
+
+AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+class DatabaseManager:
+    async def create_tables(self) -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    @asynccontextmanager
+    async def get_session(self) -> AsyncSession:
+        async with AsyncSessionLocal() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+db = DatabaseManager()


### PR DESCRIPTION
## Summary
- add `DatabaseType` and related config interfaces
- expose `createDatabaseCommands` CLI
- scaffold database selector and generator
- register db command in CLI
- add minimal database templates for MongoDB and PostgreSQL
- basic test for database command registration

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e76f04888323ae7e018c5bb804de