### PR TITLE
Add basic authentication framework

### DIFF
--- a/apps/api/src/auth/__init__.py
+++ b/apps/api/src/auth/__init__.py
@@ -1,0 +1,7 @@
+"""Authentication package"""
+
+from .services.auth import AuthService
+from .dependencies import get_auth_service
+
+__all__ = ["AuthService", "get_auth_service"]
+

--- a/apps/api/src/auth/dependencies.py
+++ b/apps/api/src/auth/dependencies.py
@@ -1,0 +1,11 @@
+"""Dependency helpers for auth"""
+import os
+from fastapi import Depends
+
+from .services.auth import AuthService
+
+
+def get_auth_service() -> AuthService:
+    secret = os.getenv("APP_SECRET_KEY", "change_me")
+    return AuthService(secret)
+

--- a/apps/api/src/auth/middleware.py
+++ b/apps/api/src/auth/middleware.py
@@ -1,0 +1,25 @@
+"""Authentication middleware"""
+from fastapi import Request, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .dependencies import get_auth_service
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Attach user to request if bearer token is valid"""
+
+    def __init__(self, app) -> None:
+        super().__init__(app)
+        self.service = get_auth_service()
+
+    async def dispatch(self, request: Request, call_next):
+        auth_header = request.headers.get("authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header.split()[1]
+            try:
+                payload = self.service.tokens.decode_token(token)
+                request.state.user_id = payload.get("sub")
+            except Exception:
+                raise HTTPException(status_code=401, detail="Invalid token")
+        return await call_next(request)
+

--- a/apps/api/src/auth/models/audit.py
+++ b/apps/api/src/auth/models/audit.py
@@ -1,0 +1,33 @@
+"""Audit log model"""
+from datetime import datetime
+from typing import Optional
+
+from beanie import Document
+from pydantic import Field
+from sqlmodel import SQLModel, Field as SQLField
+
+
+class AuditLog(Document):
+    """Audit log entry"""
+
+    user_id: Optional[str] = None
+    action: str
+    ip_address: Optional[str] = None
+    metadata: Optional[dict] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Settings:
+        collection = "audit_logs"
+        indexes = ["user_id", "action"]
+
+
+class SQLAuditLog(SQLModel, table=True):
+    """Audit log table"""
+
+    id: Optional[int] = SQLField(default=None, primary_key=True)
+    user_id: Optional[str] = None
+    action: str
+    ip_address: Optional[str] = None
+    metadata: Optional[dict] = None
+    created_at: datetime = SQLField(default_factory=datetime.utcnow)
+

--- a/apps/api/src/auth/models/rbac.py
+++ b/apps/api/src/auth/models/rbac.py
@@ -1,0 +1,52 @@
+"""RBAC models"""
+from datetime import datetime
+from typing import List, Optional
+
+from beanie import Document, Indexed
+from pydantic import Field
+from sqlmodel import SQLModel, Field as SQLField
+
+
+class Permission(Document):
+    """Permission document"""
+
+    name: Indexed(str, unique=True)
+    description: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Settings:
+        collection = "permissions"
+        indexes = ["name"]
+
+
+class Role(Document):
+    """Role document"""
+
+    name: Indexed(str, unique=True)
+    description: str
+    permissions: List[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Settings:
+        collection = "roles"
+        indexes = ["name"]
+
+
+class SQLPermission(SQLModel, table=True):
+    """Permission table"""
+
+    id: Optional[int] = SQLField(default=None, primary_key=True)
+    name: str
+    description: str
+    created_at: datetime = SQLField(default_factory=datetime.utcnow)
+
+
+class SQLRole(SQLModel, table=True):
+    """Role table"""
+
+    id: Optional[int] = SQLField(default=None, primary_key=True)
+    name: str
+    description: str
+    permissions: List[str] = SQLField(default_factory=list, sa_column_kwargs={"nullable": False})
+    created_at: datetime = SQLField(default_factory=datetime.utcnow)
+

--- a/apps/api/src/auth/models/session.py
+++ b/apps/api/src/auth/models/session.py
@@ -1,0 +1,35 @@
+"""Session and token models"""
+from datetime import datetime
+from typing import Optional
+
+from beanie import Document
+from pydantic import Field
+from sqlmodel import SQLModel, Field as SQLField
+
+
+class Session(Document):
+    """Active session for a user"""
+
+    user_id: str
+    refresh_token: str
+    user_agent: Optional[str] = None
+    ip_address: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: datetime
+
+    class Settings:
+        collection = "sessions"
+        indexes = ["user_id", "refresh_token"]
+
+
+class SQLSession(SQLModel, table=True):
+    """Session table for PostgreSQL"""
+
+    id: Optional[int] = SQLField(default=None, primary_key=True)
+    user_id: str
+    refresh_token: str
+    user_agent: Optional[str] = None
+    ip_address: Optional[str] = None
+    created_at: datetime = SQLField(default_factory=datetime.utcnow)
+    expires_at: datetime
+

--- a/apps/api/src/auth/models/user.py
+++ b/apps/api/src/auth/models/user.py
@@ -1,0 +1,47 @@
+"""User models for FARM authentication"""
+from datetime import datetime
+from typing import List, Optional
+
+from beanie import Document, Indexed
+from pydantic import BaseModel, EmailStr, Field
+from sqlmodel import SQLModel, Field as SQLField
+
+
+class UserProfile(BaseModel):
+    """Public user profile data"""
+
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+
+class MongoUser(Document):
+    """MongoDB user document"""
+
+    email: Indexed(EmailStr, unique=True)
+    username: Optional[str] = Field(default=None)
+    password_hash: str
+    roles: List[str] = Field(default_factory=list)
+    permissions: List[str] = Field(default_factory=list)
+    profile: UserProfile = Field(default_factory=UserProfile)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Settings:
+        collection = "users"
+        indexes = ["email", "username"]
+
+
+class SQLUser(SQLModel, table=True):
+    """PostgreSQL user table"""
+
+    id: Optional[int] = SQLField(default=None, primary_key=True)
+    email: EmailStr
+    username: Optional[str] = None
+    password_hash: str
+    roles: List[str] = SQLField(default_factory=list, sa_column_kwargs={"nullable": False})
+    permissions: List[str] = SQLField(default_factory=list, sa_column_kwargs={"nullable": False})
+    profile: Optional[dict] = None
+    created_at: datetime = SQLField(default_factory=datetime.utcnow)
+    updated_at: datetime = SQLField(default_factory=datetime.utcnow)
+

--- a/apps/api/src/auth/services/auth.py
+++ b/apps/api/src/auth/services/auth.py
@@ -1,0 +1,49 @@
+"""Authentication service"""
+from datetime import datetime, timedelta
+from typing import Optional
+
+from passlib.context import CryptContext
+
+from ..models.user import MongoUser
+from ..models.session import Session
+from .token import TokenService
+
+
+class AuthService:
+    """Basic auth logic for FARM"""
+
+    def __init__(self, secret: str) -> None:
+        self.pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+        self.tokens = TokenService(secret)
+
+    async def register(self, email: str, password: str) -> MongoUser:
+        existing = await MongoUser.find_one(MongoUser.email == email)
+        if existing:
+            raise ValueError("User exists")
+        user = MongoUser(email=email, password_hash=self.pwd.hash(password))
+        await user.insert()
+        return user
+
+    async def authenticate(self, email: str, password: str) -> Optional[MongoUser]:
+        user = await MongoUser.find_one(MongoUser.email == email)
+        if not user:
+            return None
+        if not self.pwd.verify(password, user.password_hash):
+            return None
+        return user
+
+    async def login(self, user: MongoUser, user_agent: str, ip: str) -> Session:
+        payload = {"sub": str(user.id), "roles": user.roles, "permissions": user.permissions}
+        access = self.tokens.create_access_token(payload, 15)
+        refresh = self.tokens.create_refresh_token(payload, 7)
+        session = Session(
+            user_id=str(user.id),
+            refresh_token=refresh,
+            user_agent=user_agent,
+            ip_address=ip,
+            created_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(days=7),
+        )
+        await session.insert()
+        return session
+

--- a/apps/api/src/auth/services/token.py
+++ b/apps/api/src/auth/services/token.py
@@ -1,0 +1,29 @@
+"""JWT token utilities"""
+from datetime import datetime, timedelta
+from typing import Dict
+
+from jose import jwt
+
+
+class TokenService:
+    """Handle issuing and verifying JWT tokens"""
+
+    def __init__(self, secret: str, algorithm: str = "HS256") -> None:
+        self.secret = secret
+        self.algorithm = algorithm
+
+    def create_access_token(self, payload: Dict[str, object], expires_minutes: int) -> str:
+        expire = datetime.utcnow() + timedelta(minutes=expires_minutes)
+        to_encode = payload.copy()
+        to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+        return jwt.encode(to_encode, self.secret, algorithm=self.algorithm)
+
+    def create_refresh_token(self, payload: Dict[str, object], expires_days: int) -> str:
+        expire = datetime.utcnow() + timedelta(days=expires_days)
+        to_encode = payload.copy()
+        to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
+        return jwt.encode(to_encode, self.secret, algorithm=self.algorithm)
+
+    def decode_token(self, token: str) -> Dict[str, object]:
+        return jwt.decode(token, self.secret, algorithms=[self.algorithm])
+

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -95,6 +95,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+try:
+    from .auth.middleware import AuthMiddleware
+
+    app.add_middleware(AuthMiddleware)
+except ImportError:
+    logger.warning("Auth middleware not available")
 
 
 # Health check endpoint
@@ -179,6 +185,17 @@ try:
 
     app.include_router(ai_routes.router, prefix="/api/ai", tags=["AI"])
     logger.info("✅ AI routes loaded")
+    try:
+        from .routes.auth import login as login_route
+        from .routes.auth import refresh as refresh_route
+        from .routes.auth import session as session_route
+
+        app.include_router(login_route.router)
+        app.include_router(refresh_route.router)
+        app.include_router(session_route.router)
+        logger.info("✅ Auth routes loaded")
+    except ImportError as e:
+        logger.warning(f"⚠️ Auth routes not available: {e}")
 except ImportError as e:
     logger.warning(f"⚠️ AI routes not available: {e}")
 

--- a/apps/api/src/routes/auth/login.py
+++ b/apps/api/src/routes/auth/login.py
@@ -1,0 +1,32 @@
+"""Auth login route"""
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, EmailStr
+
+from ...auth.services.auth import AuthService
+from ...auth.dependencies import get_auth_service
+
+router = APIRouter()
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+@router.post("/api/auth/login")
+async def login(
+    req: Request,
+    data: LoginRequest,
+    service: AuthService = Depends(get_auth_service),
+):
+    user = await service.authenticate(data.email, data.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    session = await service.login(user, req.headers.get("user-agent", ""), req.client.host)
+    return {
+        "access_token": service.tokens.create_access_token({"sub": str(user.id), "roles": user.roles, "permissions": user.permissions}, 15),
+        "refresh_token": session.refresh_token,
+        "expires_in": 900,
+        "user": {"id": str(user.id), "email": user.email, "roles": user.roles, "permissions": user.permissions},
+    }
+

--- a/apps/api/src/routes/auth/refresh.py
+++ b/apps/api/src/routes/auth/refresh.py
@@ -1,0 +1,34 @@
+"""Token refresh route"""
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from ...auth.services.auth import AuthService
+from ...auth.dependencies import get_auth_service
+from ...auth.models.user import MongoUser
+
+router = APIRouter()
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+@router.post("/api/auth/token")
+async def refresh(
+    data: RefreshRequest,
+    service: AuthService = Depends(get_auth_service),
+):
+    try:
+        payload = service.tokens.decode_token(data.refresh_token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+    user_id = payload.get("sub")
+    user = await MongoUser.get(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    access = service.tokens.create_access_token({"sub": user_id, "roles": user.roles, "permissions": user.permissions}, 15)
+    new_refresh = service.tokens.create_refresh_token({"sub": user_id, "roles": user.roles, "permissions": user.permissions}, 7)
+    return {"access_token": access, "refresh_token": new_refresh, "expires_in": 900}
+

--- a/apps/api/src/routes/auth/session.py
+++ b/apps/api/src/routes/auth/session.py
@@ -1,0 +1,26 @@
+"""Session info route"""
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ...auth.services.auth import AuthService
+from ...auth.dependencies import get_auth_service
+from ...auth.models.user import MongoUser
+
+router = APIRouter()
+
+
+@router.get("/api/auth/session")
+async def get_session(
+    req: Request,
+    service: AuthService = Depends(get_auth_service),
+):
+    token = req.headers.get("authorization")
+    if not token or not token.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Auth required")
+    payload = service.tokens.decode_token(token.split()[1])
+    user_id = payload.get("sub")
+    user = await MongoUser.get(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid user")
+    return {"user": {"id": str(user.id), "email": user.email, "roles": user.roles, "permissions": user.permissions}}
+
+

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { createGenerateCommand } from './commands/generate.js';
 import { createValidateCommands } from './commands/validate';
 import { registerTypeCommands } from './commands/types/index.js';
 import { createAddUICommand } from './commands/add-ui.js';
+import { createAuthCommands } from './commands/auth.js';
 import { createDatabaseCommands } from './commands/database.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -35,6 +36,7 @@ export function createCLI(): Command {
   program.addCommand(createGenerateCommand());
   program.addCommand(createAddUICommand());
   program.addCommand(createDatabaseCommands());
+  program.addCommand(createAuthCommands());
   program.addCommand(createValidateCommands());
   registerTypeCommands(program);
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,38 @@
+import { Command } from "commander";
+import chalk from "chalk";
+
+export function createAuthCommands(): Command {
+  const auth = new Command("auth");
+  auth.description("Authentication utilities");
+
+  auth
+    .command("scaffold")
+    .description("Scaffold base auth models")
+    .action(() => {
+      console.log(chalk.green("Auth scaffold not yet implemented"));
+    });
+
+  auth
+    .command("roles")
+    .description("List available roles")
+    .action(() => {
+      console.log(chalk.blue("Role management not yet implemented"));
+    });
+
+  auth
+    .command("tokens")
+    .description("Manage tokens")
+    .action(() => {
+      console.log(chalk.blue("Token management not yet implemented"));
+    });
+
+  auth
+    .command("dev:login")
+    .description("Generate a local development token")
+    .action(() => {
+      console.log(chalk.yellow("Dev login not yet implemented"));
+    });
+
+  return auth;
+}
+

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -6,3 +6,4 @@ export { createBuildCommand } from './build.js';
 export { registerTypeCommands } from './types/index.js';
 export { createAddUICommand } from './add-ui.js';
 export { createDatabaseCommands } from './database.js';
+export { createAuthCommands } from './auth.js';

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Authentication and Authorization Types
+ * These shared interfaces define the core auth models
+ * used across the FARM framework. All modules should
+ * reference these instead of duplicating structures.
+ */
+
+export interface Permission {
+  /** Unique permission name */
+  name: string;
+  /** Optional human friendly description */
+  description?: string;
+}
+
+export interface Role {
+  /** Role identifier */
+  name: string;
+  /** Description of the role purpose */
+  description?: string;
+  /** Permissions associated with the role */
+  permissions: string[];
+}
+
+export interface UserProfile {
+  /** Optional first name */
+  firstName?: string;
+  /** Optional last name */
+  lastName?: string;
+  /** Avatar URL for UI display */
+  avatarUrl?: string;
+}
+
+export interface User {
+  /** Unique identifier */
+  id: string;
+  /** Email used for login */
+  email: string;
+  /** Optional username */
+  username?: string;
+  /** Assigned roles */
+  roles: string[];
+  /** Explicit permissions */
+  permissions: string[];
+  /** Profile details */
+  profile?: UserProfile;
+}
+
+export interface TokenPayload {
+  /** User ID */
+  sub: string;
+  /** Token issued at timestamp */
+  iat: number;
+  /** Expiry timestamp */
+  exp: number;
+  /** Token type - access or refresh */
+  type: 'access' | 'refresh';
+  /** Roles granted to the token */
+  roles: string[];
+  /** Permissions granted to the token */
+  permissions: string[];
+}
+
+export interface Session {
+  /** Access token string */
+  accessToken: string;
+  /** Refresh token string */
+  refreshToken: string;
+  /** Expiration epoch for the access token */
+  expiresAt: number;
+  /** Authenticated user information */
+  user: User;
+}
+

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ export * from "./core.js";
 export * from "./ai.js";
 export * from "./database.js";
 export * from "./errors.js";
+export * from "./auth.js";
 
 // CLI types (separate to avoid conflicts)
 export type {


### PR DESCRIPTION
## Summary
- implement shared auth types
- add minimal auth service and token utilities for API
- scaffold Mongo/Postgres models for user, roles and sessions
- create auth routes and middleware in FastAPI
- wire CLI with `farm auth` namespace

## Testing
- `npm test` *(fails: vitest not installed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845fc94ec50832392a8fab73c3b4bed