### PR TITLE
Add JSDoc across packages

### DIFF
--- a/packages/ai/index.ts
+++ b/packages/ai/index.ts
@@ -1,9 +1,31 @@
+/**
+ * Primary exports for the `@farm/ai` package. These re-export the core
+ * provider base class, registry and configuration utilities used when
+ * integrating AI providers within FARM applications.
+ */
 import { BaseAIProvider } from "./src/providers/base";
 
+/**
+ * Base class that all AI providers must extend in order to integrate with the
+ * FARM AI subsystem.
+ *
+ * @type {typeof BaseAIProvider}
+ */
 export { BaseAIProvider };
 
 import { ProviderRegistry } from "./src/registry/provider-registry";
+/**
+ * Singleton registry used to keep track of available AI providers at runtime.
+ *
+ * @type {typeof ProviderRegistry}
+ */
 export { ProviderRegistry };
 
 import { AIConfigManager } from "./src/config/ai-config";
+/**
+ * Convenience class responsible for validating and normalising AI related
+ * configuration objects for the framework.
+ *
+ * @type {typeof AIConfigManager}
+ */
 export { AIConfigManager };

--- a/packages/ai/src/config/ai-config.ts
+++ b/packages/ai/src/config/ai-config.ts
@@ -1,5 +1,11 @@
 // packages/ai/src/config/ai-config.ts - Fix missing import
 // import type { AIConfig } from "@farm/types";
+
+/**
+ * Utility classes and helpers for managing AI provider configuration. This file
+ * defines zod based schemas that validate the configuration structure used by
+ * the FARM framework and exposes a manager class for runtime manipulation.
+ */
 import { z } from "zod";
 import { EventEmitter } from "events";
 import { getErrorMessage } from "@farm/cli";
@@ -123,6 +129,13 @@ export type AIFeaturesConfig = z.infer<typeof AIFeaturesConfigSchema>;
 export type AIConfig = z.infer<typeof AIConfigSchema>;
 
 // Configuration manager class
+/**
+ * Manages AI provider configuration at runtime. Consumers can load, validate
+ * and query provider settings using this class. It also emits a variety of
+ * events whenever configuration values change.
+ *
+ * @extends EventEmitter
+ */
 export class AIConfigManager extends EventEmitter {
   private config: AIConfig;
   private environment: string;
@@ -391,6 +404,12 @@ export class AIConfigManager extends EventEmitter {
 }
 
 // Utility functions
+/**
+ * Create a minimal default configuration object conforming to the
+ * {@link AIConfigSchema}. Useful for bootstrapping new projects.
+ *
+ * @returns {AIConfig} Parsed default configuration structure
+ */
 export function createDefaultAIConfig(): AIConfig {
   return AIConfigSchema.parse({
     providers: {},
@@ -399,6 +418,14 @@ export function createDefaultAIConfig(): AIConfig {
   });
 }
 
+/**
+ * Merge two AI configuration objects using the schema for validation. The
+ * base configuration is overwritten by the values from `override`.
+ *
+ * @param base - The existing configuration values
+ * @param override - A partial configuration to merge in
+ * @returns {AIConfig} A new validated configuration object
+ */
 export function mergeAIConfigs(
   base: AIConfig,
   override: Partial<AIConfig>

--- a/packages/ai/src/providers/base.ts
+++ b/packages/ai/src/providers/base.ts
@@ -1,6 +1,13 @@
 // packages/ai/src/providers/base.ts
 import { EventEmitter } from "events";
 
+/**
+ * Contains foundational types and the {@link BaseAIProvider} abstract class
+ * that all concrete AI provider implementations must extend. These definitions
+ * establish a consistent interface for interacting with AI models and services
+ * within the FARM framework.
+ */
+
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
   content: string;
@@ -74,6 +81,13 @@ export interface ProviderHealthCheck {
   models?: string[];
 }
 
+/**
+ * Abstract base class that all AI provider implementations must extend. It
+ * defines a common lifecycle and set of operations for interacting with AI
+ * models regardless of the underlying service.
+ *
+ * @extends EventEmitter
+ */
 export abstract class BaseAIProvider extends EventEmitter {
   public readonly name: string;
   public readonly type: string;
@@ -204,18 +218,36 @@ export abstract class BaseAIProvider extends EventEmitter {
 
 // Provider factory interface
 export interface ProviderFactory {
+  /**
+   * Create a new provider instance given a name and configuration.
+   *
+   * @param name - Unique provider identifier
+   * @param config - Provider configuration object
+   */
   create(name: string, config: ProviderConfig): BaseAIProvider;
+
+  /**
+   * Determine if this factory supports the given provider type.
+   *
+   * @param type - Provider type string
+   */
   supports(type: string): boolean;
 }
 
 // Provider registry interface
 export interface IProviderRegistry {
+  /** Register a provider factory */
   register(factory: ProviderFactory): void;
+  /** Create and register a provider instance */
   create(name: string, type: string, config: ProviderConfig): BaseAIProvider;
+  /** Get a list of supported provider types */
   getAvailableTypes(): string[];
 }
 
 // Error types
+/**
+ * Base error type thrown by provider implementations when an operation fails.
+ */
 export class ProviderError extends Error {
   constructor(message: string, public provider: string, public cause?: Error) {
     super(message);
@@ -223,6 +255,9 @@ export class ProviderError extends Error {
   }
 }
 
+/**
+ * Thrown when a requested model cannot be found by the provider.
+ */
 export class ModelNotFoundError extends ProviderError {
   constructor(model: string, provider: string) {
     super(`Model "${model}" not found in provider "${provider}"`, provider);
@@ -230,6 +265,9 @@ export class ModelNotFoundError extends ProviderError {
   }
 }
 
+/**
+ * Indicates that the provider service is currently unavailable.
+ */
 export class ProviderUnavailableError extends ProviderError {
   constructor(provider: string, cause?: Error) {
     super(`Provider "${provider}" is unavailable`, provider, cause);
@@ -237,6 +275,9 @@ export class ProviderUnavailableError extends ProviderError {
   }
 }
 
+/**
+ * Error thrown when a generation request is invalid or malformed.
+ */
 export class InvalidRequestError extends ProviderError {
   constructor(message: string, provider: string) {
     super(message, provider);

--- a/packages/core/src/codegen/extractors/graphql.ts
+++ b/packages/core/src/codegen/extractors/graphql.ts
@@ -1,6 +1,15 @@
 // packages/core/src/codegen/extractors/graphql.ts
-// Placeholder for future GraphQL schema extraction
+
+/**
+ * Extracts GraphQL schemas from a running API service. This is currently a
+ * placeholder implementation awaiting future feature work.
+ */
 export class GraphQLExtractor {
+  /**
+   * Perform the extraction process.
+   *
+   * @throws {Error} Always thrown until implementation is provided.
+   */
   async extract(): Promise<void> {
     throw new Error('GraphQL extraction not implemented yet');
   }

--- a/packages/core/src/codegen/generators/ai-hooks.ts
+++ b/packages/core/src/codegen/generators/ai-hooks.ts
@@ -2,11 +2,22 @@ import fs from "fs-extra";
 import path from "path";
 import type { OpenAPISchema } from "../types/openapi";
 
+/** Options for the {@link AIHookGenerator}. */
 export interface AIHookGeneratorOptions {
   outputDir: string;
 }
 
+/**
+ * Generates custom React hooks for interacting with AI endpoints.
+ */
 export class AIHookGenerator {
+  /**
+   * Generate AI hook source files from an OpenAPI schema.
+   *
+   * @param _schema - Parsed OpenAPI schema
+   * @param opts - Generation options
+   * @returns Path to the generated file
+   */
   async generate(
     _schema: OpenAPISchema,
     opts: AIHookGeneratorOptions

--- a/packages/core/src/codegen/generators/api-client.ts
+++ b/packages/core/src/codegen/generators/api-client.ts
@@ -2,11 +2,22 @@ import fs from "fs-extra";
 import path from "path";
 import type { OpenAPISchema } from "../types/openapi";
 
+/** Options for the {@link APIClientGenerator}. */
 export interface APIClientGeneratorOptions {
   outputDir: string;
 }
 
+/**
+ * Generates a typed API client based on the provided OpenAPI schema.
+ */
 export class APIClientGenerator {
+  /**
+   * Generate the client file.
+   *
+   * @param _schema - Parsed OpenAPI schema
+   * @param opts - Generation options
+   * @returns Path to the generated file
+   */
   async generate(
     _schema: OpenAPISchema,
     opts: APIClientGeneratorOptions

--- a/packages/core/src/codegen/generators/react-hooks.ts
+++ b/packages/core/src/codegen/generators/react-hooks.ts
@@ -2,11 +2,22 @@ import fs from "fs-extra";
 import path from "path";
 import type { OpenAPISchema } from "../types/openapi";
 
+/** Options for the {@link ReactHookGenerator}. */
 export interface ReactHookGeneratorOptions {
   outputDir: string;
 }
 
+/**
+ * Generates typed React hooks for interacting with the generated API client.
+ */
 export class ReactHookGenerator {
+  /**
+   * Generate hook source files.
+   *
+   * @param _schema - Parsed OpenAPI schema
+   * @param opts - Generation options
+   * @returns Path to the generated file
+   */
   async generate(
     _schema: OpenAPISchema,
     opts: ReactHookGeneratorOptions

--- a/packages/core/src/codegen/generators/typescript.ts
+++ b/packages/core/src/codegen/generators/typescript.ts
@@ -2,11 +2,22 @@ import fs from "fs-extra";
 import path from "path";
 import type { OpenAPISchema } from "../types/openapi";
 
+/** Options for the {@link TypeScriptGenerator}. */
 export interface TypeScriptGenerationOptions {
   outputDir: string;
 }
 
+/**
+ * Generates raw TypeScript type declarations from an OpenAPI schema.
+ */
 export class TypeScriptGenerator {
+  /**
+   * Generate the type declaration file.
+   *
+   * @param _schema - Parsed OpenAPI schema
+   * @param opts - Generation options
+   * @returns Path to the generated file
+   */
   async generate(
     _schema: OpenAPISchema,
     opts: TypeScriptGenerationOptions

--- a/packages/core/src/codegen/orchestrator.ts
+++ b/packages/core/src/codegen/orchestrator.ts
@@ -5,6 +5,9 @@ import { APIClientGenerator } from "./generators/api-client";
 import { ReactHookGenerator } from "./generators/react-hooks";
 import { AIHookGenerator } from "./generators/ai-hooks";
 
+/**
+ * Options controlling the behaviour of the {@link CodegenOrchestrator}.
+ */
 export interface CodegenOptions {
   apiUrl: string;
   outputDir: string;
@@ -15,6 +18,9 @@ export interface CodegenOptions {
   };
 }
 
+/**
+ * Result object returned from a code generation run.
+ */
 export interface CodegenResult {
   filesGenerated: number;
   artifacts?: string[];
@@ -24,6 +30,11 @@ interface Generator {
   generate: (schema: OpenAPISchema, opts: any) => Promise<{ path: string }>;
 }
 
+/**
+ * Coordinates extraction of API schemas and generation of TypeScript artifacts
+ * such as clients and hooks. Acts as the top-level entry point for the
+ * code-generation pipeline.
+ */
 export class CodegenOrchestrator {
   private extractor = new OpenAPIExtractor();
   private generators = new Map<string, Generator>();
@@ -52,6 +63,11 @@ export class CodegenOrchestrator {
     );
   }
 
+  /**
+   * Configure the orchestrator prior to execution.
+   *
+   * @param config - Runtime options for code generation
+   */
   async initialize(config: CodegenOptions) {
     this.config = config;
   }
@@ -64,6 +80,11 @@ export class CodegenOrchestrator {
     return true;
   }
 
+  /**
+   * Execute the full code generation pipeline.
+   *
+   * @returns Summary information about the generated artifacts
+   */
   async run(): Promise<CodegenResult> {
     if (!this.config) throw new Error("Orchestrator not initialized");
     const schema = await this.extractor

--- a/packages/type-sync/src/watcher.ts
+++ b/packages/type-sync/src/watcher.ts
@@ -4,6 +4,10 @@ import fs from "fs-extra";
 import { debounce } from "lodash";
 import { TypeSyncOrchestrator } from "./orchestrator";
 
+/**
+ * Watches Python source files for changes and triggers TypeScript type
+ * regeneration when modifications are detected.
+ */
 export class TypeSyncWatcher {
   private watcher: chokidar.FSWatcher | null = null;
   private syncInProgress = false;
@@ -12,6 +16,9 @@ export class TypeSyncWatcher {
     // Debounce is now applied directly to the event handler registration, not to the method itself.
   }
 
+  /**
+   * Begin watching the configured file globs and respond to changes.
+   */
   async start() {
     this.watcher = chokidar.watch(
       [
@@ -32,6 +39,9 @@ export class TypeSyncWatcher {
     console.log("👀 Watching for Python model changes...");
   }
 
+  /**
+   * Stop watching for file changes.
+   */
   async stop() {
     await this.watcher?.close();
   }
@@ -55,6 +65,10 @@ export class TypeSyncWatcher {
     }
   };
 
+  /**
+   * Touch a file within the generated types directory so that the frontend
+   * development server can react to new types.
+   */
   private async notifyFrontend() {
     const triggerPath = ".farm/types/generated/.timestamp";
     await fs.ensureFile(triggerPath);

--- a/packages/ui-components/src/providers/query-provider.tsx
+++ b/packages/ui-components/src/providers/query-provider.tsx
@@ -11,11 +11,13 @@ interface QueryErrorInfo {
   error: Error | null;
 }
 
+/** Props for {@link QueryProvider}. */
 interface QueryProviderProps {
   children: ReactNode;
   client?: QueryClient;
 }
 
+// Error handler functions with proper typing
 // Error handler functions with proper typing
 const defaultQueryErrorHandler = (error: Error, query: any) => {
   console.error("Query error:", error, query);
@@ -61,6 +63,10 @@ const createQueryClient = () => {
   });
 };
 
+/**
+ * Wrapper component that provides a configured React Query client to the
+ * component tree.
+ */
 export function QueryProvider({ children, client }: QueryProviderProps) {
   const queryClient = client || createQueryClient();
 
@@ -73,6 +79,9 @@ export function QueryProvider({ children, client }: QueryProviderProps) {
 }
 
 // Query invalidation helper hook
+/**
+ * Convenience hook providing helpers to invalidate cached queries.
+ */
 export function useInvalidateQueries() {
   const queryClient = useQueryClient();
 
@@ -100,6 +109,10 @@ interface QueryErrorBoundaryProps {
   fallback?: (error: Error) => ReactNode;
 }
 
+/**
+ * React error boundary that specifically handles errors thrown from React
+ * Query hooks within its child component tree.
+ */
 export class QueryErrorBoundary extends Component<
   QueryErrorBoundaryProps,
   QueryErrorBoundaryState


### PR DESCRIPTION
## Summary
- document AI package exports with JSDoc
- add docs for AI configuration manager and helpers
- document base AI provider and related types
- document codegen extractors and generators
- describe orchestrator workflow and methods
- add documentation to TypeSync watcher
- document query provider and hooks for UI components

## Testing
- `pnpm test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460fd1f3e08323af36323e34d9f2cf