### PR TITLE
Add JSDoc annotations across packages

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -306,6 +306,11 @@ export class AISystem extends EventEmitter {
   }
 
   // Private helper methods
+  /**
+   * Initialize providers defined in the supplied configuration.
+   *
+   * @param config - Parsed AI configuration
+   */
   private async initializeProvidersFromConfig(config: AIConfig): Promise<void> {
     const enabledProviders = this.configManager.getEnabledProviders();
 
@@ -332,6 +337,12 @@ export class AISystem extends EventEmitter {
     }
   }
 
+  /**
+   * Choose an appropriate provider based on preference and health status.
+   *
+   * @param preferredProvider - Optional preferred provider name
+   * @returns The selected provider instance or `null` if none available
+   */
   private async selectProvider(
     preferredProvider?: string
   ): Promise<BaseAIProvider | null> {
@@ -356,6 +367,10 @@ export class AISystem extends EventEmitter {
     return await this.registry.getHealthyProvider();
   }
 
+  /**
+   * Register event handlers for the configuration manager, registry and
+   * health checker to forward events to consumers.
+   */
   private setupEventHandlers(): void {
     // Configuration events
     this.configManager.on("provider-added", (event) => {
@@ -399,18 +414,22 @@ export class AISystem extends EventEmitter {
   }
 
   // Getters for accessing components
+  /** Get access to the underlying {@link AIConfigManager}. */
   public get config(): AIConfigManager {
     return this.configManager;
   }
 
+  /** Access the provider registry used by this system. */
   public get providers(): ProviderRegistry {
     return this.registry;
   }
 
+  /** Retrieve the health checker instance monitoring providers. */
   public get health(): HealthChecker {
     return this.healthChecker;
   }
 
+  /** Get the global error handler used by the system. */
   public get errors(): AIErrorHandler {
     return this.errorHandler;
   }

--- a/packages/core/src/codegen/extractors/openapi.ts
+++ b/packages/core/src/codegen/extractors/openapi.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 
 const { readFile, writeFile, ensureDir } = fsExtra;
 
+/** Options controlling how the OpenAPI schema is extracted. */
 export interface OpenAPIExtractionOptions {
   include?: string[];
   exclude?: string[];
@@ -12,9 +13,17 @@ export interface OpenAPIExtractionOptions {
   timeout?: number;
 }
 
+/**
+ * Helper responsible for retrieving an OpenAPI schema from a FastAPI project.
+ */
 export class OpenAPIExtractor {
   private options: OpenAPIExtractionOptions;
 
+  /**
+   * Create a new extractor instance.
+   *
+   * @param options - Optional default extraction settings
+   */
   constructor(options: OpenAPIExtractionOptions = {}) {
     this.options = {
       host: "localhost",
@@ -24,6 +33,13 @@ export class OpenAPIExtractor {
     };
   }
 
+  /**
+   * Extract the schema from a running or temporary FastAPI server.
+   *
+   * @param apiPath - Path to the FastAPI application
+   * @param outputPath - File path where the schema should be written
+   * @param options - Additional extraction options
+   */
   async extractFromFastAPI(
     apiPath: string,
     outputPath: string,
@@ -47,6 +63,9 @@ export class OpenAPIExtractor {
     }
   }
 
+  /**
+   * Attempt to fetch the schema from a currently running server.
+   */
   private async fetchSchemaFromServer(
     options: OpenAPIExtractionOptions
   ): Promise<any | null> {
@@ -62,6 +81,10 @@ export class OpenAPIExtractor {
     return null;
   }
 
+  /**
+   * Launch a temporary server to generate the OpenAPI schema when one isn't
+   * already running.
+   */
   private async generateSchemaWithTempServer(
     apiPath: string,
     outputPath: string,

--- a/packages/core/src/codegen/utils/ast-helpers.ts
+++ b/packages/core/src/codegen/utils/ast-helpers.ts
@@ -1,4 +1,12 @@
 // Placeholder for AST manipulation utilities
+
+/**
+ * Prepend an import statement to the provided TypeScript source string.
+ *
+ * @param source - Original source code
+ * @param statement - Import statement to insert
+ * @returns Modified source with the import prepended
+ */
 export function addImport(source: string, statement: string): string {
-  return statement + '\n' + source;
+  return statement + "\n" + source;
 }

--- a/packages/core/src/codegen/utils/schema-validator.ts
+++ b/packages/core/src/codegen/utils/schema-validator.ts
@@ -1,5 +1,13 @@
 type OpenAPIV3 = any;
 
+/**
+ * Perform a lightweight check that the provided value resembles an OpenAPI v3
+ * schema definition.
+ *
+ * @param schema - Potential schema object
+ * @returns True if the object exposes required OpenAPI properties
+ */
+
 export function validateSchema(schema: unknown): boolean {
   return (
     typeof schema === "object" &&


### PR DESCRIPTION
## Summary
- document provider base methods
- expand AI configuration manager documentation
- annotate health checker utilities and events
- document OpenAPI extractor and utility helpers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684611e6a38c83238761cb46e81828d1