### PR TITLE
Mark duplicated types as deprecated

### DIFF
--- a/packages/ai/src/errors/error-handler.ts
+++ b/packages/ai/src/errors/error-handler.ts
@@ -23,6 +23,9 @@ export enum ErrorSeverity {
   CRITICAL = "critical",
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface ErrorContext {
   provider?: string;
   model?: string;

--- a/packages/cli/src/template/definitions.ts
+++ b/packages/cli/src/template/definitions.ts
@@ -1,4 +1,7 @@
 // packages/cli/src/templates/definitions.ts
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface TemplateDefinition {
   name: string;
   displayName: string;

--- a/packages/cli/src/template/helpers.ts
+++ b/packages/cli/src/template/helpers.ts
@@ -17,10 +17,16 @@ interface HandlebarsOptions {
   inverse: (context: any) => string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 interface DatabaseConfig {
   type?: "mongodb" | "postgresql" | "mysql" | "sqlite";
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 interface AIProviderConfig {
   enabled?: boolean;
   url?: string;
@@ -33,6 +39,9 @@ interface AIProviderConfig {
   gpu?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 interface AIConfig {
   providers?: {
     ollama?: AIProviderConfig;
@@ -71,6 +80,9 @@ type TemplateName =
 type DatabaseType = "mongodb" | "postgresql" | "mysql" | "sqlite";
 type EnvironmentName = "development" | "staging" | "production";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 interface TemplateContext {
   // Project configuration
   config?: TemplateContext;

--- a/packages/cli/src/template/types.ts
+++ b/packages/cli/src/template/types.ts
@@ -26,6 +26,9 @@ export type TemplateName =
   | "api-only";
 export type EnvironmentName = "development" | "staging" | "production";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DatabaseConfig {
   type: DatabaseType;
   url?: string;
@@ -48,6 +51,9 @@ export interface AIProviderConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface AIConfig {
   providers?: {
     ollama?: AIProviderConfig;
@@ -67,6 +73,9 @@ export interface AIConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DevelopmentConfig {
   ports?: {
     frontend?: number;
@@ -82,6 +91,9 @@ export interface DevelopmentConfig {
   ssl?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface BuildConfig {
   target?: string;
   sourcemap?: boolean;
@@ -90,14 +102,23 @@ export interface BuildConfig {
   outDir?: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DeploymentConfig {
   platform?: "vercel" | "netlify" | "aws" | "gcp" | "docker";
   regions?: string[];
   environment?: Record<string, string>;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export type PluginConfig = string | [string, Record<string, any>];
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface FarmConfig {
   // Project metadata
   name: string;
@@ -144,6 +165,7 @@ export interface FarmConfig {
 /**
  * Template context that gets passed to Handlebars templates
  * This extends FarmConfig with additional computed properties
+ * @deprecated Moved to `@farm/types` package
  */
 export interface TemplateContext extends FarmConfig {
   // The config property allows templates to access the full config
@@ -196,6 +218,9 @@ export interface TemplateDirectory {
   targetPath?: string; // Allow legacy property for compatibility
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface TemplateDefinition {
   name: TemplateName;
   description: string;

--- a/packages/cli/src/utils/error-handling.ts
+++ b/packages/cli/src/utils/error-handling.ts
@@ -2,6 +2,9 @@
  * Error handling utilities for FARM CLI
  */
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface ErrorContext {
   command?: string;
   operation?: string;

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -2,6 +2,9 @@
 import inquirer from "inquirer";
 import { input, select, checkbox, confirm } from "@inquirer/prompts";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface PromptChoice {
   name: string;
   value: string;

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -4,6 +4,9 @@ import { homedir } from "os";
 import { readFile } from "fs/promises";
 import { join } from "path";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface ValidationResult {
   valid: boolean;
   error?: string;

--- a/tools/cli/commands/types.ts
+++ b/tools/cli/commands/types.ts
@@ -1,4 +1,7 @@
 // tools/cli/commands/types.ts
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface GenerateOptions {
   watch?: boolean;
   config?: string;
@@ -7,22 +10,34 @@ export interface GenerateOptions {
   ai?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface GenerateAllOptions extends GenerateOptions {
   watch?: boolean;
   config?: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface GenerateHooksOptions extends GenerateOptions {
   schema?: string;
   output?: string;
   ai?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface GenerateTypesOptions extends GenerateOptions {
   schema?: string;
   output?: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface GenerateClientOptions extends GenerateOptions {
   schema?: string;
   output?: string;

--- a/tools/codegen/src/schema/cli/schema.ts
+++ b/tools/codegen/src/schema/cli/schema.ts
@@ -10,6 +10,9 @@ import { SchemaWatcher, SchemaWatcherOptions } from "../watcher";
 import { getErrorMessage } from "@farm/cli";
 import { get } from "lodash";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 interface CLIOptions {
   projectRoot?: string;
   output?: string;

--- a/tools/codegen/src/type-generator.ts
+++ b/tools/codegen/src/type-generator.ts
@@ -521,6 +521,9 @@ export interface ApiError {
   timestamp: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface AIProvider {
   name: 'ollama' | 'openai' | 'huggingface';
   status: 'healthy' | 'unhealthy' | 'loading';

--- a/tools/dev-server/src/types.ts
+++ b/tools/dev-server/src/types.ts
@@ -69,6 +69,9 @@ export interface DevServerOptions {
 }
 
 // FARM configuration types (from existing types package)
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface FarmConfig {
   name?: string;
   template: TemplateType;
@@ -79,6 +82,9 @@ export interface FarmConfig {
   plugins?: PluginConfig[];
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export type TemplateType =
   | "basic"
   | "ai-chat"
@@ -87,6 +93,9 @@ export type TemplateType =
   | "cms"
   | "api-only";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export type FeatureType =
   | "auth"
   | "ai"
@@ -97,12 +106,18 @@ export type FeatureType =
   | "search"
   | "analytics";
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DatabaseConfig {
   type: "mongodb" | "postgresql" | "mysql" | "sqlite";
   url?: string;
   options?: Record<string, any>;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface AIConfig {
   providers?: {
     ollama?: OllamaConfig;
@@ -122,6 +137,9 @@ export interface AIConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface OllamaConfig {
   enabled: boolean;
   url?: string;
@@ -132,6 +150,9 @@ export interface OllamaConfig {
   gpu?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface OpenAIConfig {
   enabled: boolean;
   apiKey?: string;
@@ -143,6 +164,9 @@ export interface OpenAIConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface HuggingFaceConfig {
   enabled: boolean;
   token?: string;
@@ -150,6 +174,9 @@ export interface HuggingFaceConfig {
   device?: "auto" | "cpu" | "cuda";
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DevelopmentConfig {
   ports?: {
     frontend?: number;
@@ -166,6 +193,9 @@ export interface DevelopmentConfig {
   ssl?: boolean;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export type PluginConfig = string | [string, Record<string, any>];
 
 // Development server events
@@ -306,6 +336,9 @@ export type Awaitable<T> = T | Promise<T>;
 export type EventHandler<T extends keyof DevServerEvents> = DevServerEvents[T];
 
 // Configuration validation
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface ValidationResult {
   valid: boolean;
   errors: string[];

--- a/tools/template-validator/src/types.ts
+++ b/tools/template-validator/src/types.ts
@@ -17,6 +17,9 @@ export interface ProviderConfig {
   defaultModel: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface AIConfig {
   providers: ProviderConfig[];
   routing: {
@@ -32,6 +35,9 @@ export interface AIConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface DatabaseConfig {
   type: "mongodb" | "postgresql" | "mysql" | "sqlite";
   url: string;
@@ -185,6 +191,9 @@ export interface TestConfiguration {
 }
 
 // Provider-specific configurations
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface OllamaConfig extends ProviderConfig {
   gpu: boolean;
   autoStart: boolean;
@@ -192,6 +201,9 @@ export interface OllamaConfig extends ProviderConfig {
   memoryLimit?: string;
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface OpenAIConfig extends ProviderConfig {
   organization?: string;
   rateLimiting: {
@@ -200,6 +212,9 @@ export interface OpenAIConfig extends ProviderConfig {
   };
 }
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface HuggingFaceConfig extends ProviderConfig {
   token?: string;
   device: "auto" | "cpu" | "cuda";

--- a/tools/testing/types.ts
+++ b/tools/testing/types.ts
@@ -1,5 +1,8 @@
 // tools/testing/types.ts
 
+/**
+ * @deprecated Moved to `@farm/types` package
+ */
 export interface TemplateConfig {
   template:
     | "basic"


### PR DESCRIPTION
## Summary
- add `@deprecated` notes for locally defined types that now exist in `@farm/types`

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846186e48c883239be2c88a0eb516d3