### PR TITLE
Update CLI to use @farm/type-sync generators

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,7 +1,7 @@
 # Tools: CLI helpers
 
 Command modules used internally by the monorepo.  The `generate` command
-wraps the code generation pipeline defined in `@farm/codegen`.
+relies on the type-sync utilities provided by `@farm/type-sync`.
 
 ## Structure
 

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -9,7 +9,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@farm/codegen": "workspace:*",
+    "@farm/type-sync": "workspace:*",
     "commander": "^11.0.0",
     "fs-extra": "^11.1.1",
     "chalk": "^5.3.0"


### PR DESCRIPTION
## Summary
- remove `@farm/codegen` in favor of `@farm/type-sync`
- use `ReactHookGenerator` to generate React hooks
- fetch `TypeScriptGenerator` and `APIClientGenerator` from `@farm/type-sync`
- update `generate all` to rely on the TypeSync orchestrator
- document the new dependency in README

## Testing
- `pnpm test` *(fails: vitest not found and other suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68469078ac808323af296a745783905c