### PR TITLE
Add type audit report for code-intelligence

### DIFF
--- a/types-map/package-code-intelligence.md
+++ b/types-map/package-code-intelligence.md
@@ -1,0 +1,20 @@
+# Type Audit Report for package: code-intelligence
+
+## 📦 Target
+- **Type:** package
+- **Name:** code-intelligence
+
+## 📁 Local Types Summary
+No TypeScript files were found in this package, so no local type, interface, enum, or class declarations were detected.
+
+## 🔁 Shared Type Cross-Reference
+- ✅ None required. There are no local declarations that should import from `@farm/types`.
+- ❌ No duplicate types detected across other packages.
+- ⚠️ None.
+
+## 🚫 Violations
+None. Since the package contains no TypeScript files, there are no redundant or out-of-sync type definitions.
+
+## ✅ Suggestions for Sync
+If TypeScript code is added to this package in the future, ensure any shared types are moved to `packages/types` and imported via `@farm/types`.
+


### PR DESCRIPTION
## Summary
- analyze `packages/code-intelligence` for local types
- create report `types-map/package-code-intelligence.md`

No TS files were found in the package, so no violations are present.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cd2ca0e8483239e1dee11d51123e9